### PR TITLE
`OnlineMoments::observe` computes the wrong variance because delta is a lazy Eigen expression

### DIFF
--- a/include/walnutpie/online_moments.hpp
+++ b/include/walnutpie/online_moments.hpp
@@ -183,10 +183,7 @@ class OnlineMoments {
    */
   template <typename Derived>
   void observe(const Eigen::MatrixBase<Derived>& y) {
-    // Materialize the deviation BEFORE updating mean_: `auto delta = ...`
-    // would bind a lazy expression referencing mean_, and the sum_sq_dev_
-    // line would then evaluate (y - mean_new)^2 instead of the Welford
-    // cross-term delta_old * (y - mean_new) this class documents.
+    // Keep the deviation from the old mean for the variance update.
     const Eigen::VectorXd delta = (y - mean_).eval();
     weight_ = discount_factor_ * weight_ + 1;
     mean_ += delta / weight_;

--- a/include/walnutpie/online_moments.hpp
+++ b/include/walnutpie/online_moments.hpp
@@ -183,7 +183,11 @@ class OnlineMoments {
    */
   template <typename Derived>
   void observe(const Eigen::MatrixBase<Derived>& y) {
-    auto delta = y - mean_;
+    // Materialize the deviation BEFORE updating mean_: `auto delta = ...`
+    // would bind a lazy expression referencing mean_, and the sum_sq_dev_
+    // line would then evaluate (y - mean_new)^2 instead of the Welford
+    // cross-term delta_old * (y - mean_new) this class documents.
+    const Eigen::VectorXd delta = (y - mean_).eval();
     weight_ = discount_factor_ * weight_ + 1;
     mean_ += delta / weight_;
     sum_sq_dev_.noalias() =


### PR DESCRIPTION
`OnlineMoments::observe()` stores `y - mean_` in `auto delta`, then changes `mean_` before using `delta` in the variance update. Eigen evaluates that expression against the new mean, rather than the previous mean required by Welford's update. With discounting disabled, equally weighted observations 0, 1 and 2 produce variance `5/12` instead of `2/3`.

```cpp
#include <walnutpie/online_moments.hpp>
#include <iostream>

int main() {
  // The initial state represents one observation at zero.
  walnutpie::detail::OnlineMoments moments(
      1.0, Eigen::VectorXd::Zero(1), Eigen::VectorXd::Zero(1));
  moments.set_discount_factor(1.0);

  Eigen::VectorXd y(1);
  y << 1.0;
  moments.observe(y);
  y << 2.0;
  moments.observe(y);

  std::cout << moments.variance()[0] << '\n';
  // Actual: 0.416667. Expected population variance: 0.666667.
}
```