### PR TITLE
Validate both chain-view indices before accessing storage

### DIFF
--- a/include/walnutpie/summary.hpp
+++ b/include/walnutpie/summary.hpp
@@ -317,7 +317,7 @@ class MarkovChainsUnified {
    * the number of chains.
    */
   Eigen::Ref<const Eigen::MatrixXd> chain_view(std::size_t m) const {
-    return draws_.middleRows(chain_starts_.at(m), chain_sizes_[m]);
+    return draws_.middleRows(chain_starts_.at(m), chain_sizes_.at(m));
   }
 
   /**

--- a/tests/summary_test.cpp
+++ b/tests/summary_test.cpp
@@ -196,6 +196,14 @@ TEST(MarkovChainsUnified, ChainViewThrowsOnOutOfRangeIndex) {
   walnutpie::MarkovChainsUnified mcu(draws, chain_sizes);
   EXPECT_THROW(mcu.chain_view(3), std::out_of_range);
   EXPECT_THROW(mcu.chain_view(99), std::out_of_range);
+  EXPECT_THROW(mcu.chain_view(std::numeric_limits<std::size_t>::max()),
+               std::out_of_range);
+}
+
+TEST(MarkovChainsUnified, EmptyCollectionChainViewThrows) {
+  Eigen::MatrixXd draws(0, 2);
+  walnutpie::MarkovChainsUnified mcu(draws, {});
+  EXPECT_THROW(mcu.chain_view(0), std::out_of_range);
 }
 
 // draws


### PR DESCRIPTION
`MarkovChainsUnified::chain_view()` promises `std::out_of_range` for an invalid chain index, but its two arguments mix checked and unchecked indexing, maybe just a typo?

C++ does not require the checked argument to run first. GCC 16 reproduces an out-of-bounds read before the exception. With libstdc++ assertions enabled, the existing bounds test aborts.
