### PR TITLE
Add opt-in deterministic endpoint reuse

### DIFF
--- a/docs/cpp.rst
+++ b/docs/cpp.rst
@@ -55,26 +55,14 @@ The following concepts describe the types expected by `walnutpie`.
 .. doxygenconcept:: walnutpie::GlobalHandler
 .. doxygenconcept:: walnutpie::InterruptCallback
 
-Endpoint reuse (opt-in)
------------------------
+Endpoint reuse
+--------------
 
-``WalnutsSampler`` and ``AdaptiveWalnuts`` accept a final constructor argument,
-``walnutpie::EndpointReuse::Deterministic``. The default is ``Disabled``.
-For a stable target, reuse avoids one density/gradient evaluation per transition
-following the first. A finite warmup endpoint also transfers to the fixed sampler.
-With zero warmup, the fixed sampler evaluates its first endpoint normally.
-
-Opt in only when the target returns the same results for the same position.
-Target results must not depend on evaluation counts or handler side effects.
-After changing target data between draws, call ``invalidate_endpoint_cache()``
-on every affected sampler. A warmup-complete handler that changes target data
-must invalidate the adaptive sampler before it returns, or the caller must
-invalidate the returned fixed sampler before drawing. Invalidation does not
-make samples from a changing target suitable for inference.
-
-Reuse retains only finite density and gradient values. Failed or nonfinite
-endpoints are reevaluated. Draw and warmup callbacks retain their order and
-frequency; error callbacks report actual thrown evaluations, not cache hits.
-Caches are copied by value; RNG, target, and handler references retain their
-existing ownership rules. The high-level configuration and Python API do not
-enable this option.
+Samplers reuse finite endpoint density/gradient values automatically. Targets
+must return the same results for the same position. After changing target data,
+call ``invalidate_endpoint_cache()`` on each affected sampler, including from
+callbacks that make such changes. A warmup-complete callback must invalidate
+the adaptive sampler before returning, or invalidate the returned fixed sampler
+before drawing. This does not make changing-target draws valid for inference.
+Failed/nonfinite endpoints are reevaluated. Zero warmup starts with no endpoint;
+otherwise the fixed sampler inherits the adaptive sampler's finite endpoint.

--- a/docs/cpp.rst
+++ b/docs/cpp.rst
@@ -54,15 +54,3 @@ The following concepts describe the types expected by `walnutpie`.
 .. doxygenconcept:: walnutpie::ChainHandler
 .. doxygenconcept:: walnutpie::GlobalHandler
 .. doxygenconcept:: walnutpie::InterruptCallback
-
-Endpoint reuse
---------------
-
-Samplers reuse finite endpoint density/gradient values automatically. Targets
-must return the same results for the same position. After changing target data,
-call ``invalidate_endpoint_cache()`` on each affected sampler, including from
-callbacks that make such changes. A warmup-complete callback must invalidate
-the adaptive sampler before returning, or invalidate the returned fixed sampler
-before drawing. This does not make changing-target draws valid for inference.
-Failed/nonfinite endpoints are reevaluated. Zero warmup starts with no endpoint;
-otherwise the fixed sampler inherits the adaptive sampler's finite endpoint.

--- a/docs/cpp.rst
+++ b/docs/cpp.rst
@@ -54,3 +54,27 @@ The following concepts describe the types expected by `walnutpie`.
 .. doxygenconcept:: walnutpie::ChainHandler
 .. doxygenconcept:: walnutpie::GlobalHandler
 .. doxygenconcept:: walnutpie::InterruptCallback
+
+Endpoint reuse (opt-in)
+-----------------------
+
+``WalnutsSampler`` and ``AdaptiveWalnuts`` accept a final constructor argument,
+``walnutpie::EndpointReuse::Deterministic``. The default is ``Disabled``.
+For a stable target, reuse avoids one density/gradient evaluation per transition
+following the first. A finite warmup endpoint also transfers to the fixed sampler.
+With zero warmup, the fixed sampler evaluates its first endpoint normally.
+
+Opt in only when the target returns the same results for the same position.
+Target results must not depend on evaluation counts or handler side effects.
+After changing target data between draws, call ``invalidate_endpoint_cache()``
+on every affected sampler. A warmup-complete handler that changes target data
+must invalidate the adaptive sampler before it returns, or the caller must
+invalidate the returned fixed sampler before drawing. Invalidation does not
+make samples from a changing target suitable for inference.
+
+Reuse retains only finite density and gradient values. Failed or nonfinite
+endpoints are reevaluated. Draw and warmup callbacks retain their order and
+frequency; error callbacks report actual thrown evaluations, not cache hits.
+Caches are copied by value; RNG, target, and handler references retain their
+existing ownership rules. The high-level configuration and Python API do not
+enable this option.

--- a/include/walnutpie/adaptive_walnuts.hpp
+++ b/include/walnutpie/adaptive_walnuts.hpp
@@ -196,9 +196,6 @@ class AdaptiveWalnuts {
    * modifed.
    * @param[in,out] handler Event handler for adaptation and sampling, stored by
    * reference and called back.
-   * Finite endpoint values are reused. Targets must be stable at each position.
-   * Call invalidate_endpoint_cache() after changing target data.
-   *
    * @param[in] logp_grad The target log density and gradient function.
    * @param[in] init_chain_cfg The initialization configuration for a single
    * chain.
@@ -223,7 +220,9 @@ class AdaptiveWalnuts {
               warmup_cfg.step_learn_rate_decay()),
         mass_estimator_(warmup_cfg, init_chain_cfg),
         min_micro_estimator_(warmup_cfg.max_macro_steps_target(),
-                             sampling_cfg.min_micro_steps()) {}
+                             sampling_cfg.min_micro_steps()) {
+    logp_grad_(theta_, logp_, grad_);
+  }
 
   /**
    * @brief Generate the next state for adaptation and the handler.
@@ -238,20 +237,16 @@ class AdaptiveWalnuts {
     Eigen::VectorXd inv_mass = mass_estimator_.inv_mass_estimate();
     Eigen::VectorXd chol_mass = inv_mass.array().inverse().sqrt().matrix();
     std::size_t depth;
-    theta_ = detail::transition_w_impl(
-        rand_, logp_grad_, inv_mass, chol_mass, adam_.step_size(),
-        sampling_cfg_.get().max_trajectory_doublings(),
-        sampling_cfg_.get().max_step_halvings(),
-        min_micro_estimator_.min_micro_steps(),
-        sampling_cfg_.get().max_hamiltonian_error(), std::move(theta_), depth,
-        endpoint_gradient_, endpoint_logp_, adam_,
-        endpoint_valid_ ? &endpoint_gradient_ : nullptr, endpoint_logp_);
-    mass_estimator_.observe(theta_, endpoint_gradient_, iteration_);
+    theta_ =
+        transition_w(rand_, logp_grad_, inv_mass, chol_mass, adam_.step_size(),
+                     sampling_cfg_.get().max_trajectory_doublings(),
+                     sampling_cfg_.get().max_step_halvings(),
+                     min_micro_estimator_.min_micro_steps(),
+                     sampling_cfg_.get().max_hamiltonian_error(),
+                     std::move(theta_), depth, grad_, logp_, adam_);
+    mass_estimator_.observe(theta_, grad_, iteration_);
     min_micro_estimator_.observe(1 << depth);
-    endpoint_valid_ =
-        std::isfinite(endpoint_logp_) && endpoint_gradient_.allFinite();
-    double logp = endpoint_logp_;
-    handler_.get().on_warmup(theta_, logp, step_size(), inv_mass);
+    handler_.get().on_warmup(theta_, logp_, step_size(), inv_mass);
     ++iteration_;
   }
 
@@ -267,21 +262,13 @@ class AdaptiveWalnuts {
    */
   WalnutsSampler<F, RNG, H> sampler() {
     handler_.get().on_warmup_complete(step_size(), inv_mass());
-    WalnutsSampler<F, RNG, H> result(
+    return WalnutsSampler<F, RNG, H>(
         rand_.rng(), handler_, logp_grad_.logp_grad_, theta_, inv_mass(),
         step_size(), sampling_cfg_.get().max_trajectory_doublings(),
         sampling_cfg_.get().max_step_halvings(),
         min_micro_estimator_.min_micro_steps(),
         sampling_cfg_.get().max_hamiltonian_error());
-    result.endpoint_gradient_ = endpoint_gradient_;
-    result.endpoint_logp_ = endpoint_logp_;
-    result.endpoint_valid_ = endpoint_valid_;
-    return result;
   }
-
-  /** Targets must be stable at each position. Call after target-data changes,
-   * including changes in callbacks, to force the next endpoint evaluation. */
-  void invalidate_endpoint_cache() noexcept { endpoint_valid_ = false; }
 
   /**
    * @brief Return the diagonal of the diagonal inverse mass matrix.
@@ -361,9 +348,11 @@ class AdaptiveWalnuts {
   /** The current state. */
   Eigen::VectorXd theta_;
 
-  Eigen::VectorXd endpoint_gradient_;
-  double endpoint_logp_ = 0;
-  bool endpoint_valid_ = false;
+  /** The gradient of the log density at `theta_`. */
+  Eigen::VectorXd grad_;
+
+  /** The log density at `theta_`. */
+  double logp_;
 
   /** The current iteration. */
   std::size_t iteration_;

--- a/include/walnutpie/adaptive_walnuts.hpp
+++ b/include/walnutpie/adaptive_walnuts.hpp
@@ -201,17 +201,23 @@ class AdaptiveWalnuts {
    * chain.
    * @param[in] warmup_cfg The warmup configuration.
    * @param[in] sampling_cfg The sampling configuration.
+   * @param[in] endpoint_reuse Deterministic reuse requires a stable,
+   * position-only target, including across warmup and completion callbacks.
+   * Invalidate after changes. The returned sampler inherits this policy and
+   * any finite endpoint; zero warmup leaves the cache empty.
    */
   AdaptiveWalnuts(RNG& rng, H& handler, const F& logp_grad,
                   const InitChainConfig& init_chain_cfg,
                   const WarmupConfig& warmup_cfg,
-                  const SamplingConfig& sampling_cfg)
+                  const SamplingConfig& sampling_cfg,
+                  EndpointReuse endpoint_reuse = EndpointReuse::Disabled)
       : warmup_cfg_(std::cref(warmup_cfg)),
         sampling_cfg_(std::cref(sampling_cfg)),
         rand_(rng),
         handler_(handler),
         logp_grad_(logp_grad, handler),
         theta_(init_chain_cfg.position()),
+        endpoint_reuse_(endpoint_reuse),
         iteration_(0),
         adam_(init_chain_cfg.step_size(), warmup_cfg.step_accept_rate_target(),
               warmup_cfg.step_learning_rate(), warmup_cfg.step_gradient_decay(),
@@ -237,15 +243,20 @@ class AdaptiveWalnuts {
     Eigen::VectorXd grad_select;
     double logp_select;
     std::size_t depth;
-    theta_ =
-        transition_w(rand_, logp_grad_, inv_mass, chol_mass, adam_.step_size(),
-                     sampling_cfg_.get().max_trajectory_doublings(),
-                     sampling_cfg_.get().max_step_halvings(),
-                     min_micro_estimator_.min_micro_steps(),
-                     sampling_cfg_.get().max_hamiltonian_error(),
-                     std::move(theta_), depth, grad_select, logp_select, adam_);
+    theta_ = detail::transition_w_impl(
+        rand_, logp_grad_, inv_mass, chol_mass, adam_.step_size(),
+        sampling_cfg_.get().max_trajectory_doublings(),
+        sampling_cfg_.get().max_step_halvings(),
+        min_micro_estimator_.min_micro_steps(),
+        sampling_cfg_.get().max_hamiltonian_error(), std::move(theta_), depth,
+        grad_select, logp_select, adam_,
+        endpoint_reuse_ == EndpointReuse::Deterministic ? &endpoint_cache_
+                                                        : nullptr);
     mass_estimator_.observe(theta_, grad_select, iteration_);
     min_micro_estimator_.observe(1 << depth);
+    if (endpoint_reuse_ == EndpointReuse::Deterministic) {
+      endpoint_cache_.store(std::move(grad_select), logp_select);
+    }
     handler_.get().on_warmup(theta_, logp_select, step_size(), inv_mass);
     ++iteration_;
   }
@@ -262,13 +273,18 @@ class AdaptiveWalnuts {
    */
   WalnutsSampler<F, RNG, H> sampler() {
     handler_.get().on_warmup_complete(step_size(), inv_mass());
-    return WalnutsSampler<F, RNG, H>(
+    WalnutsSampler<F, RNG, H> result(
         rand_.rng(), handler_, logp_grad_.logp_grad_, theta_, inv_mass(),
         step_size(), sampling_cfg_.get().max_trajectory_doublings(),
         sampling_cfg_.get().max_step_halvings(),
         min_micro_estimator_.min_micro_steps(),
-        sampling_cfg_.get().max_hamiltonian_error());
+        sampling_cfg_.get().max_hamiltonian_error(), endpoint_reuse_);
+    result.endpoint_cache_ = endpoint_cache_;
+    return result;
   }
+
+  /** Discard the endpoint after changing target data between draws. */
+  void invalidate_endpoint_cache() noexcept { endpoint_cache_.valid = false; }
 
   /**
    * @brief Return the diagonal of the diagonal inverse mass matrix.
@@ -347,6 +363,9 @@ class AdaptiveWalnuts {
 
   /** The current state. */
   Eigen::VectorXd theta_;
+
+  EndpointReuse endpoint_reuse_;
+  detail::EndpointCache endpoint_cache_;
 
   /** The current iteration. */
   std::size_t iteration_;

--- a/include/walnutpie/adaptive_walnuts.hpp
+++ b/include/walnutpie/adaptive_walnuts.hpp
@@ -196,28 +196,25 @@ class AdaptiveWalnuts {
    * modifed.
    * @param[in,out] handler Event handler for adaptation and sampling, stored by
    * reference and called back.
+   * Finite endpoint values are reused. Targets must be stable at each position.
+   * Call invalidate_endpoint_cache() after changing target data.
+   *
    * @param[in] logp_grad The target log density and gradient function.
    * @param[in] init_chain_cfg The initialization configuration for a single
    * chain.
    * @param[in] warmup_cfg The warmup configuration.
    * @param[in] sampling_cfg The sampling configuration.
-   * @param[in] endpoint_reuse Deterministic reuse requires a stable,
-   * position-only target, including across warmup and completion callbacks.
-   * Invalidate after changes. The returned sampler inherits this policy and
-   * any finite endpoint; zero warmup leaves the cache empty.
    */
   AdaptiveWalnuts(RNG& rng, H& handler, const F& logp_grad,
                   const InitChainConfig& init_chain_cfg,
                   const WarmupConfig& warmup_cfg,
-                  const SamplingConfig& sampling_cfg,
-                  EndpointReuse endpoint_reuse = EndpointReuse::Disabled)
+                  const SamplingConfig& sampling_cfg)
       : warmup_cfg_(std::cref(warmup_cfg)),
         sampling_cfg_(std::cref(sampling_cfg)),
         rand_(rng),
         handler_(handler),
         logp_grad_(logp_grad, handler),
         theta_(init_chain_cfg.position()),
-        endpoint_reuse_(endpoint_reuse),
         iteration_(0),
         adam_(init_chain_cfg.step_size(), warmup_cfg.step_accept_rate_target(),
               warmup_cfg.step_learning_rate(), warmup_cfg.step_gradient_decay(),
@@ -240,8 +237,6 @@ class AdaptiveWalnuts {
   void operator()() {
     Eigen::VectorXd inv_mass = mass_estimator_.inv_mass_estimate();
     Eigen::VectorXd chol_mass = inv_mass.array().inverse().sqrt().matrix();
-    Eigen::VectorXd grad_select;
-    double logp_select;
     std::size_t depth;
     theta_ = detail::transition_w_impl(
         rand_, logp_grad_, inv_mass, chol_mass, adam_.step_size(),
@@ -249,15 +244,14 @@ class AdaptiveWalnuts {
         sampling_cfg_.get().max_step_halvings(),
         min_micro_estimator_.min_micro_steps(),
         sampling_cfg_.get().max_hamiltonian_error(), std::move(theta_), depth,
-        grad_select, logp_select, adam_,
-        endpoint_reuse_ == EndpointReuse::Deterministic ? &endpoint_cache_
-                                                        : nullptr);
-    mass_estimator_.observe(theta_, grad_select, iteration_);
+        endpoint_gradient_, endpoint_logp_, adam_,
+        endpoint_valid_ ? &endpoint_gradient_ : nullptr, endpoint_logp_);
+    mass_estimator_.observe(theta_, endpoint_gradient_, iteration_);
     min_micro_estimator_.observe(1 << depth);
-    if (endpoint_reuse_ == EndpointReuse::Deterministic) {
-      endpoint_cache_.store(std::move(grad_select), logp_select);
-    }
-    handler_.get().on_warmup(theta_, logp_select, step_size(), inv_mass);
+    endpoint_valid_ =
+        std::isfinite(endpoint_logp_) && endpoint_gradient_.allFinite();
+    double logp = endpoint_logp_;
+    handler_.get().on_warmup(theta_, logp, step_size(), inv_mass);
     ++iteration_;
   }
 
@@ -278,13 +272,16 @@ class AdaptiveWalnuts {
         step_size(), sampling_cfg_.get().max_trajectory_doublings(),
         sampling_cfg_.get().max_step_halvings(),
         min_micro_estimator_.min_micro_steps(),
-        sampling_cfg_.get().max_hamiltonian_error(), endpoint_reuse_);
-    result.endpoint_cache_ = endpoint_cache_;
+        sampling_cfg_.get().max_hamiltonian_error());
+    result.endpoint_gradient_ = endpoint_gradient_;
+    result.endpoint_logp_ = endpoint_logp_;
+    result.endpoint_valid_ = endpoint_valid_;
     return result;
   }
 
-  /** Discard the endpoint after changing target data between draws. */
-  void invalidate_endpoint_cache() noexcept { endpoint_cache_.valid = false; }
+  /** Targets must be stable at each position. Call after target-data changes,
+   * including changes in callbacks, to force the next endpoint evaluation. */
+  void invalidate_endpoint_cache() noexcept { endpoint_valid_ = false; }
 
   /**
    * @brief Return the diagonal of the diagonal inverse mass matrix.
@@ -364,8 +361,9 @@ class AdaptiveWalnuts {
   /** The current state. */
   Eigen::VectorXd theta_;
 
-  EndpointReuse endpoint_reuse_;
-  detail::EndpointCache endpoint_cache_;
+  Eigen::VectorXd endpoint_gradient_;
+  double endpoint_logp_ = 0;
+  bool endpoint_valid_ = false;
 
   /** The current iteration. */
   std::size_t iteration_;

--- a/include/walnutpie/walnuts.hpp
+++ b/include/walnutpie/walnuts.hpp
@@ -512,32 +512,27 @@ static std::optional<SpanW> build_span(Random<RNG>& rng, const F& logp_grad,
  * @param[in] max_error The maximum difference in Hamiltonians.
  * @param[in] theta The current state.
  * @param[out] depth The tree depth used by the transition.
- * @param[out] theta_grad The gradient of the log density at the selected state.
- * @param[out] logp_pos_select The log density of the selected position.
+ * @param[in,out] theta_grad The gradient of the log density at `theta` on
+ * input; the gradient at the selected state on output.
+ * @param[in,out] logp_pos_select The log density of `theta` on input; the
+ * log density of the selected position on output.
  * @param[in,out] step_size_adapter The step-size adaptation handler.
  * @return The next position in the Markov chain.
  */
 template <LogpGrad F, class Rand, StepSizeAdapter A>
-inline Eigen::VectorXd transition_w_impl(
+inline Eigen::VectorXd transition_w(
     Rand& rand, const F& logp_grad, const Eigen::VectorXd& inv_mass,
     const Eigen::VectorXd& chol_mass, double step, std::size_t max_depth,
     std::size_t max_step_halvings, std::size_t min_micro_steps,
     double max_error, Eigen::VectorXd&& theta, std::size_t& depth,
-    Eigen::VectorXd& theta_grad, double& logp_pos_select, A& step_size_adapter,
-    const Eigen::VectorXd* initial_gradient, double initial_logp) {
+    Eigen::VectorXd& theta_grad, double& logp_pos_select,
+    A& step_size_adapter) {
   auto z = rand.standard_normal(chol_mass.size());
   Eigen::VectorXd rho = (chol_mass.array() * z.array()).matrix();
-  Eigen::VectorXd grad(theta.size());
-  double logp_pos;
-  if (initial_gradient && initial_gradient->size() == theta.size()) {
-    grad = *initial_gradient;
-    logp_pos = initial_logp;
-  } else {
-    logp_grad(theta, logp_pos, grad);
-  }
-  double logp_joint = logp_pos + logp_momentum(rho, inv_mass);
-  auto span_accum = SpanW::from_initial_point(
-      std::move(theta), std::move(rho), std::move(grad), logp_pos, logp_joint);
+  double logp_joint = logp_pos_select + logp_momentum(rho, inv_mass);
+  auto span_accum = SpanW::from_initial_point(std::move(theta), std::move(rho),
+                                              std::move(theta_grad),
+                                              logp_pos_select, logp_joint);
   for (depth = 1; depth <= max_depth; ++depth) {
     // helper to turn runtime direction into compile-time template enum
     auto expand_in_direction = [&](auto direction) -> bool {
@@ -565,21 +560,6 @@ inline Eigen::VectorXd transition_w_impl(
   theta_grad = span_accum.grad_select_;
   logp_pos_select = span_accum.logp_pos_select_;
   return std::move(span_accum.theta_select_);
-}
-
-/** Uncached entry point retained for existing callers. */
-template <LogpGrad F, class Rand, StepSizeAdapter A>
-inline Eigen::VectorXd transition_w(
-    Rand& rand, const F& logp_grad, const Eigen::VectorXd& inv_mass,
-    const Eigen::VectorXd& chol_mass, double step, std::size_t max_depth,
-    std::size_t max_step_halvings, std::size_t min_micro_steps,
-    double max_error, Eigen::VectorXd&& theta, std::size_t& depth,
-    Eigen::VectorXd& theta_grad, double& logp_pos_select,
-    A& step_size_adapter) {
-  return transition_w_impl(rand, logp_grad, inv_mass, chol_mass, step,
-                           max_depth, max_step_halvings, min_micro_steps,
-                           max_error, std::move(theta), depth, theta_grad,
-                           logp_pos_select, step_size_adapter, nullptr, 0);
 }
 
 /**
@@ -631,9 +611,6 @@ class WalnutsSampler {
    *
    * @param[in,out] rng The base random number generator.
    * @param[in,out] sample_handler The sampling and on-stop event handler.
-   * Finite endpoint values are reused. Targets must be stable at each position.
-   * Call invalidate_endpoint_cache() after changing target data.
-   *
    * @param[in] logp_grad The target log density and gradient function (see the
    * class documentation.
    * @param[in] theta The initial position.
@@ -680,6 +657,7 @@ class WalnutsSampler {
     detail::validate_positive(max_step_halvings, "max_step_halvings");
     detail::validate_positive(min_micro_steps, "min_micro_steps");
     detail::validate_positive(max_error, "max_error");
+    logp_grad_(theta_, logp_, grad_);
   }
 
   /**
@@ -704,22 +682,13 @@ class WalnutsSampler {
    */
   double operator()() {
     std::size_t depth;
-    theta_ = detail::transition_w_impl(
-        rand_, logp_grad_, inv_mass_, cholesky_mass_, macro_time_,
-        max_nuts_depth_, max_step_halvings_, min_micro_steps_, max_error_,
-        std::move(theta_), depth, endpoint_gradient_, endpoint_logp_,
-        no_op_step_size_adapter_,
-        endpoint_valid_ ? &endpoint_gradient_ : nullptr, endpoint_logp_);
-    endpoint_valid_ =
-        std::isfinite(endpoint_logp_) && endpoint_gradient_.allFinite();
-    double logp = endpoint_logp_;
-    sample_handler_.get().on_sample(theta_, logp);
-    return logp;
+    theta_ = transition_w(rand_, logp_grad_, inv_mass_, cholesky_mass_,
+                          macro_time_, max_nuts_depth_, max_step_halvings_,
+                          min_micro_steps_, max_error_, std::move(theta_),
+                          depth, grad_, logp_, no_op_step_size_adapter_);
+    sample_handler_.get().on_sample(theta_, logp_);
+    return logp_;
   }
-
-  /** Targets must be stable at each position. Call after target-data changes,
-   * including changes in callbacks, to force the next endpoint evaluation. */
-  void invalidate_endpoint_cache() noexcept { endpoint_valid_ = false; }
 
   /**
    * @brief  Return a constant reference the diagonal of the diagonal inverse
@@ -758,9 +727,6 @@ class WalnutsSampler {
   }
 
  private:
-  template <LogpGrad G, std::uniform_random_bit_generator R, ChainHandler C>
-  friend class AdaptiveWalnuts;
-
   /** The underlying randomizer. */
   detail::Random<RNG> rand_;
 
@@ -773,9 +739,11 @@ class WalnutsSampler {
   /** The current position. */
   Eigen::VectorXd theta_;
 
-  Eigen::VectorXd endpoint_gradient_;
-  double endpoint_logp_ = 0;
-  bool endpoint_valid_ = false;
+  /** The gradient of the log density at `theta_`. */
+  Eigen::VectorXd grad_;
+
+  /** The log density at `theta_`. */
+  double logp_;
 
   /** The diagonal of the diagonal inverse mass matrix. */
   Eigen::VectorXd inv_mass_;

--- a/include/walnutpie/walnuts.hpp
+++ b/include/walnutpie/walnuts.hpp
@@ -17,7 +17,29 @@
 #include "walnutpie/util.hpp"
 #include "walnutpie/validate.hpp"
 
+namespace walnutpie {
+/** Endpoint reuse is opt-in because LogpGrad does not require a stable target.
+ */
+enum class EndpointReuse { Disabled, Deterministic };
+}  // namespace walnutpie
+
 namespace walnutpie::detail {
+
+/** A value-owned, finite endpoint. The owner keeps it paired with its position.
+ */
+struct EndpointCache {
+  bool valid = false;
+  Eigen::VectorXd gradient;
+  double logp = 0;
+
+  void store(Eigen::VectorXd&& grad, double lp) {
+    valid = std::isfinite(lp) && grad.allFinite();
+    if (valid) {
+      gradient = std::move(grad);
+      logp = lp;
+    }
+  }
+};
 
 /**
  * @brief A class for holding the minimal information in a Hamiltonian
@@ -512,24 +534,29 @@ static std::optional<SpanW> build_span(Random<RNG>& rng, const F& logp_grad,
  * @param[in] max_error The maximum difference in Hamiltonians.
  * @param[in] theta The current state.
  * @param[out] depth The tree depth used by the transition.
- * @param[out] theta_grad The gradient of the log density at the previous state.
+ * @param[out] theta_grad The gradient of the log density at the selected state.
  * @param[out] logp_pos_select The log density of the selected position.
  * @param[in,out] step_size_adapter The step-size adaptation handler.
  * @return The next position in the Markov chain.
  */
 template <LogpGrad F, class Rand, StepSizeAdapter A>
-inline Eigen::VectorXd transition_w(
+inline Eigen::VectorXd transition_w_impl(
     Rand& rand, const F& logp_grad, const Eigen::VectorXd& inv_mass,
     const Eigen::VectorXd& chol_mass, double step, std::size_t max_depth,
     std::size_t max_step_halvings, std::size_t min_micro_steps,
     double max_error, Eigen::VectorXd&& theta, std::size_t& depth,
-    Eigen::VectorXd& theta_grad, double& logp_pos_select,
-    A& step_size_adapter) {
+    Eigen::VectorXd& theta_grad, double& logp_pos_select, A& step_size_adapter,
+    const EndpointCache* cache) {
   auto z = rand.standard_normal(chol_mass.size());
   Eigen::VectorXd rho = (chol_mass.array() * z.array()).matrix();
   Eigen::VectorXd grad(theta.size());
   double logp_pos;
-  logp_grad(theta, logp_pos, grad);
+  if (cache && cache->valid && cache->gradient.size() == theta.size()) {
+    grad = cache->gradient;
+    logp_pos = cache->logp;
+  } else {
+    logp_grad(theta, logp_pos, grad);
+  }
   double logp_joint = logp_pos + logp_momentum(rho, inv_mass);
   auto span_accum = SpanW::from_initial_point(
       std::move(theta), std::move(rho), std::move(grad), logp_pos, logp_joint);
@@ -560,6 +587,21 @@ inline Eigen::VectorXd transition_w(
   theta_grad = span_accum.grad_select_;
   logp_pos_select = span_accum.logp_pos_select_;
   return std::move(span_accum.theta_select_);
+}
+
+/** Uncached entry point retained for existing callers. */
+template <LogpGrad F, class Rand, StepSizeAdapter A>
+inline Eigen::VectorXd transition_w(
+    Rand& rand, const F& logp_grad, const Eigen::VectorXd& inv_mass,
+    const Eigen::VectorXd& chol_mass, double step, std::size_t max_depth,
+    std::size_t max_step_halvings, std::size_t min_micro_steps,
+    double max_error, Eigen::VectorXd&& theta, std::size_t& depth,
+    Eigen::VectorXd& theta_grad, double& logp_pos_select,
+    A& step_size_adapter) {
+  return transition_w_impl(rand, logp_grad, inv_mass, chol_mass, step,
+                           max_depth, max_step_halvings, min_micro_steps,
+                           max_error, std::move(theta), depth, theta_grad,
+                           logp_pos_select, step_size_adapter, nullptr);
 }
 
 /**
@@ -622,6 +664,10 @@ class WalnutsSampler {
    * halved.
    * @param[in] min_micro_steps The minimum number of micro steps per macro
    * step.
+   * @param[in] endpoint_reuse Deterministic reuse requires a position-only,
+   * stable target, including across handler callbacks. Evaluation side effects
+   * must not affect target results. Invalidate the cache after target changes.
+   * The default preserves reevaluation and exception retry behavior.
    * @param[in] max_error The log of the maximum error in joint densities
    * allowed in Hamiltonian trajectories.
    * @throw std::invalid_argument If `inv_mass_matrix` has non-positive or
@@ -638,11 +684,13 @@ class WalnutsSampler {
                  const Eigen::VectorXd& theta, const Eigen::VectorXd& inv_mass,
                  double macro_time, std::size_t max_nuts_depth,
                  std::size_t max_step_halvings, std::size_t min_micro_steps,
-                 double max_error)
+                 double max_error,
+                 EndpointReuse endpoint_reuse = EndpointReuse::Disabled)
       : rand_(rng),
         sample_handler_(sample_handler),
         logp_grad_(logp_grad, sample_handler),
         theta_(theta),
+        endpoint_reuse_(endpoint_reuse),
         inv_mass_(inv_mass),
         cholesky_mass_(inv_mass.array().sqrt().inverse().matrix()),
         macro_time_(macro_time),
@@ -683,13 +731,21 @@ class WalnutsSampler {
     std::size_t depth;
     Eigen::VectorXd grad_next;
     double logp_pos;
-    theta_ = transition_w(rand_, logp_grad_, inv_mass_, cholesky_mass_,
-                          macro_time_, max_nuts_depth_, max_step_halvings_,
-                          min_micro_steps_, max_error_, std::move(theta_),
-                          depth, grad_next, logp_pos, no_op_step_size_adapter_);
+    theta_ = detail::transition_w_impl(
+        rand_, logp_grad_, inv_mass_, cholesky_mass_, macro_time_,
+        max_nuts_depth_, max_step_halvings_, min_micro_steps_, max_error_,
+        std::move(theta_), depth, grad_next, logp_pos, no_op_step_size_adapter_,
+        endpoint_reuse_ == EndpointReuse::Deterministic ? &endpoint_cache_
+                                                        : nullptr);
+    if (endpoint_reuse_ == EndpointReuse::Deterministic) {
+      endpoint_cache_.store(std::move(grad_next), logp_pos);
+    }
     sample_handler_.get().on_sample(theta_, logp_pos);
     return logp_pos;
   }
+
+  /** Discard the endpoint after changing target data between draws. */
+  void invalidate_endpoint_cache() noexcept { endpoint_cache_.valid = false; }
 
   /**
    * @brief  Return a constant reference the diagonal of the diagonal inverse
@@ -728,6 +784,9 @@ class WalnutsSampler {
   }
 
  private:
+  template <LogpGrad G, std::uniform_random_bit_generator R, ChainHandler C>
+  friend class AdaptiveWalnuts;
+
   /** The underlying randomizer. */
   detail::Random<RNG> rand_;
 
@@ -739,6 +798,9 @@ class WalnutsSampler {
 
   /** The current position. */
   Eigen::VectorXd theta_;
+
+  EndpointReuse endpoint_reuse_;
+  detail::EndpointCache endpoint_cache_;
 
   /** The diagonal of the diagonal inverse mass matrix. */
   Eigen::VectorXd inv_mass_;

--- a/include/walnutpie/walnuts.hpp
+++ b/include/walnutpie/walnuts.hpp
@@ -17,29 +17,7 @@
 #include "walnutpie/util.hpp"
 #include "walnutpie/validate.hpp"
 
-namespace walnutpie {
-/** Endpoint reuse is opt-in because LogpGrad does not require a stable target.
- */
-enum class EndpointReuse { Disabled, Deterministic };
-}  // namespace walnutpie
-
 namespace walnutpie::detail {
-
-/** A value-owned, finite endpoint. The owner keeps it paired with its position.
- */
-struct EndpointCache {
-  bool valid = false;
-  Eigen::VectorXd gradient;
-  double logp = 0;
-
-  void store(Eigen::VectorXd&& grad, double lp) {
-    valid = std::isfinite(lp) && grad.allFinite();
-    if (valid) {
-      gradient = std::move(grad);
-      logp = lp;
-    }
-  }
-};
 
 /**
  * @brief A class for holding the minimal information in a Hamiltonian
@@ -546,14 +524,14 @@ inline Eigen::VectorXd transition_w_impl(
     std::size_t max_step_halvings, std::size_t min_micro_steps,
     double max_error, Eigen::VectorXd&& theta, std::size_t& depth,
     Eigen::VectorXd& theta_grad, double& logp_pos_select, A& step_size_adapter,
-    const EndpointCache* cache) {
+    const Eigen::VectorXd* initial_gradient, double initial_logp) {
   auto z = rand.standard_normal(chol_mass.size());
   Eigen::VectorXd rho = (chol_mass.array() * z.array()).matrix();
   Eigen::VectorXd grad(theta.size());
   double logp_pos;
-  if (cache && cache->valid && cache->gradient.size() == theta.size()) {
-    grad = cache->gradient;
-    logp_pos = cache->logp;
+  if (initial_gradient && initial_gradient->size() == theta.size()) {
+    grad = *initial_gradient;
+    logp_pos = initial_logp;
   } else {
     logp_grad(theta, logp_pos, grad);
   }
@@ -601,7 +579,7 @@ inline Eigen::VectorXd transition_w(
   return transition_w_impl(rand, logp_grad, inv_mass, chol_mass, step,
                            max_depth, max_step_halvings, min_micro_steps,
                            max_error, std::move(theta), depth, theta_grad,
-                           logp_pos_select, step_size_adapter, nullptr);
+                           logp_pos_select, step_size_adapter, nullptr, 0);
 }
 
 /**
@@ -653,6 +631,9 @@ class WalnutsSampler {
    *
    * @param[in,out] rng The base random number generator.
    * @param[in,out] sample_handler The sampling and on-stop event handler.
+   * Finite endpoint values are reused. Targets must be stable at each position.
+   * Call invalidate_endpoint_cache() after changing target data.
+   *
    * @param[in] logp_grad The target log density and gradient function (see the
    * class documentation.
    * @param[in] theta The initial position.
@@ -664,10 +645,6 @@ class WalnutsSampler {
    * halved.
    * @param[in] min_micro_steps The minimum number of micro steps per macro
    * step.
-   * @param[in] endpoint_reuse Deterministic reuse requires a position-only,
-   * stable target, including across handler callbacks. Evaluation side effects
-   * must not affect target results. Invalidate the cache after target changes.
-   * The default preserves reevaluation and exception retry behavior.
    * @param[in] max_error The log of the maximum error in joint densities
    * allowed in Hamiltonian trajectories.
    * @throw std::invalid_argument If `inv_mass_matrix` has non-positive or
@@ -684,13 +661,11 @@ class WalnutsSampler {
                  const Eigen::VectorXd& theta, const Eigen::VectorXd& inv_mass,
                  double macro_time, std::size_t max_nuts_depth,
                  std::size_t max_step_halvings, std::size_t min_micro_steps,
-                 double max_error,
-                 EndpointReuse endpoint_reuse = EndpointReuse::Disabled)
+                 double max_error)
       : rand_(rng),
         sample_handler_(sample_handler),
         logp_grad_(logp_grad, sample_handler),
         theta_(theta),
-        endpoint_reuse_(endpoint_reuse),
         inv_mass_(inv_mass),
         cholesky_mass_(inv_mass.array().sqrt().inverse().matrix()),
         macro_time_(macro_time),
@@ -729,23 +704,22 @@ class WalnutsSampler {
    */
   double operator()() {
     std::size_t depth;
-    Eigen::VectorXd grad_next;
-    double logp_pos;
     theta_ = detail::transition_w_impl(
         rand_, logp_grad_, inv_mass_, cholesky_mass_, macro_time_,
         max_nuts_depth_, max_step_halvings_, min_micro_steps_, max_error_,
-        std::move(theta_), depth, grad_next, logp_pos, no_op_step_size_adapter_,
-        endpoint_reuse_ == EndpointReuse::Deterministic ? &endpoint_cache_
-                                                        : nullptr);
-    if (endpoint_reuse_ == EndpointReuse::Deterministic) {
-      endpoint_cache_.store(std::move(grad_next), logp_pos);
-    }
-    sample_handler_.get().on_sample(theta_, logp_pos);
-    return logp_pos;
+        std::move(theta_), depth, endpoint_gradient_, endpoint_logp_,
+        no_op_step_size_adapter_,
+        endpoint_valid_ ? &endpoint_gradient_ : nullptr, endpoint_logp_);
+    endpoint_valid_ =
+        std::isfinite(endpoint_logp_) && endpoint_gradient_.allFinite();
+    double logp = endpoint_logp_;
+    sample_handler_.get().on_sample(theta_, logp);
+    return logp;
   }
 
-  /** Discard the endpoint after changing target data between draws. */
-  void invalidate_endpoint_cache() noexcept { endpoint_cache_.valid = false; }
+  /** Targets must be stable at each position. Call after target-data changes,
+   * including changes in callbacks, to force the next endpoint evaluation. */
+  void invalidate_endpoint_cache() noexcept { endpoint_valid_ = false; }
 
   /**
    * @brief  Return a constant reference the diagonal of the diagonal inverse
@@ -799,8 +773,9 @@ class WalnutsSampler {
   /** The current position. */
   Eigen::VectorXd theta_;
 
-  EndpointReuse endpoint_reuse_;
-  detail::EndpointCache endpoint_cache_;
+  Eigen::VectorXd endpoint_gradient_;
+  double endpoint_logp_ = 0;
+  bool endpoint_valid_ = false;
 
   /** The diagonal of the diagonal inverse mass matrix. */
   Eigen::VectorXd inv_mass_;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,3 +39,5 @@ endfunction()
 add_test(summary)
 add_test(config)
 add_test(util)
+
+add_test(endpoint)

--- a/tests/endpoint_test.cpp
+++ b/tests/endpoint_test.cpp
@@ -94,40 +94,49 @@ auto sampling_config() {
       .max_step_halvings(8)
       .build();
 }
+template <typename S>
+auto draw_with_reuse(S& sampler, bool reuse = true) {
+  if (!reuse) {
+    sampler.invalidate_endpoint_cache();
+  }
+  return sampler();
+}
 struct Run {
   Bits trace;
   std::size_t calls;
+  std::mt19937_64 rng;
 };
-Run chain(int kind, unsigned seed, EndpointReuse policy, int warmup = 100) {
+Run chain(int kind, unsigned seed, bool reuse, int warmup = 100) {
   Target t{kind};
   Handler h;
   std::mt19937_64 rng(seed);
   auto init = InitChainConfig(0.2, zero(), ones());
   auto wc = WarmupConfigBuilder().build();
   auto sc = sampling_config();
-  AdaptiveWalnuts a(rng, h, t, init, wc, sc, policy);
+  AdaptiveWalnuts a(rng, h, t, init, wc, sc);
   for (int i = 0; i < warmup; ++i) {
-    a();
+    draw_with_reuse(a, reuse);
   }
   auto before = t.calls;
   auto sampler = a.sampler();
   EXPECT_EQ(before, t.calls);
   for (int i = 0; i < 100; ++i) {
-    auto lp = sampler();
+    auto lp = draw_with_reuse(sampler, reuse);
     EXPECT_EQ(std::bit_cast<std::uint64_t>(lp), h.trace.back());
   }
   EXPECT_EQ(h.warmups, warmup);
   EXPECT_EQ(h.samples, 100);
   EXPECT_EQ(h.freezes, 1);
   EXPECT_EQ(h.errors, 0);
-  return {h.trace, t.calls};
+  return {h.trace, t.calls, rng};
 }
 TEST(EndpointReuse, AnalyticParityAndCounts) {
   for (int kind = 0; kind < 3; ++kind) {
     for (unsigned seed : {17u, 20260819u}) {
-      auto off = chain(kind, seed, EndpointReuse::Disabled);
-      auto on = chain(kind, seed, EndpointReuse::Deterministic);
+      auto off = chain(kind, seed, false);
+      auto on = chain(kind, seed, true);
       EXPECT_EQ(off.trace, on.trace);
+      EXPECT_EQ(off.rng, on.rng);
       EXPECT_EQ(off.calls - on.calls, 199);
       std::cout << "endpoint kind=" << kind << " seed=" << seed
                 << " baseline=" << off.calls << " cached=" << on.calls << "\n";
@@ -135,9 +144,10 @@ TEST(EndpointReuse, AnalyticParityAndCounts) {
   }
 }
 TEST(EndpointReuse, ZeroWarmupAndColdSampler) {
-  auto off = chain(0, 17, EndpointReuse::Disabled, 0);
-  auto on = chain(0, 17, EndpointReuse::Deterministic, 0);
+  auto off = chain(0, 17, false, 0);
+  auto on = chain(0, 17, true, 0);
   EXPECT_EQ(off.trace, on.trace);
+  EXPECT_EQ(off.rng, on.rng);
   EXPECT_EQ(off.calls - on.calls, 99);
   std::size_t calls[2];
   Bits traces[2];
@@ -145,11 +155,9 @@ TEST(EndpointReuse, ZeroWarmupAndColdSampler) {
     Target t;
     Handler h;
     std::mt19937_64 rng(17);
-    WalnutsSampler s(
-        rng, h, t, zero(), ones(), 0.2, 4, 8, 1, 1.0,
-        enabled ? EndpointReuse::Deterministic : EndpointReuse::Disabled);
+    WalnutsSampler s(rng, h, t, zero(), ones(), 0.2, 4, 8, 1, 1.0);
     for (int i = 0; i < 100; ++i) {
-      s();
+      draw_with_reuse(s, enabled);
     }
     calls[enabled] = t.calls;
     traces[enabled] = h.trace;
@@ -166,18 +174,16 @@ TEST(EndpointReuse, InvalidEndpointsRetryAndRecover) {
       t.failure = failure;
       Handler h;
       std::mt19937_64 rng(17);
-      WalnutsSampler s(
-          rng, h, t, zero(), ones(), 0.1, 1, 1, 1, 1.0,
-          enabled ? EndpointReuse::Deterministic : EndpointReuse::Disabled);
+      WalnutsSampler s(rng, h, t, zero(), ones(), 0.1, 1, 1, 1, 1.0);
       for (int i = 0; i < 3; ++i) {
-        s();
+        draw_with_reuse(s, enabled);
       }
       EXPECT_EQ(t.calls, 6);
       EXPECT_EQ(h.errors, failure == 1 ? 6 : 0);
       t.failure = 0;  // invalid endpoints must not prevent retry/recovery
-      s();
+      draw_with_reuse(s, enabled);
       EXPECT_EQ(t.calls, 8);
-      s();
+      draw_with_reuse(s, enabled);
       calls[enabled] = t.calls;
       errors[enabled] = h.errors;
       traces[enabled] = h.trace;
@@ -194,11 +200,9 @@ TEST(EndpointReuse, RejectedTrajectoryKeepsFiniteEndpoint) {
     t.failure = 4;
     Handler h;
     std::mt19937_64 rng(17);
-    WalnutsSampler s(
-        rng, h, t, zero(), ones(), 0.1, 1, 1, 1, 1.0,
-        enabled ? EndpointReuse::Deterministic : EndpointReuse::Disabled);
+    WalnutsSampler s(rng, h, t, zero(), ones(), 0.1, 1, 1, 1, 1.0);
     for (int i = 0; i < 3; ++i) {
-      s();
+      draw_with_reuse(s, enabled);
     }
     EXPECT_EQ(t.calls, enabled ? 4 : 6);
     EXPECT_EQ(h.errors, 3);
@@ -216,8 +220,7 @@ TEST(EndpointReuse, InvalidationAndDefaultMutableTarget) {
     std::mt19937_64 rng(17);
     // The default constructor API remains valid.
     WalnutsSampler plain(rng, h, t, zero(), ones(), 0.1, 1, 1, 1, 1.0);
-    WalnutsSampler cached(rng, h, t, zero(), ones(), 0.1, 1, 1, 1, 1.0,
-                          EndpointReuse::Deterministic);
+    WalnutsSampler cached(rng, h, t, zero(), ones(), 0.1, 1, 1, 1, 1.0);
     h.after_sample = [&] {
       t.offset += 100;
       cached.invalidate_endpoint_cache();
@@ -226,7 +229,7 @@ TEST(EndpointReuse, InvalidationAndDefaultMutableTarget) {
       if (enabled) {
         cached();
       } else {
-        plain();
+        draw_with_reuse(plain, false);
       }
     }
     counts[enabled] = t.calls;
@@ -246,18 +249,16 @@ TEST(EndpointReuse, WarmupCallbackInvalidation) {
     auto init = InitChainConfig(0.2, zero(), ones());
     auto wc = WarmupConfigBuilder().build();
     auto sc = sampling_config();
-    AdaptiveWalnuts a(
-        rng, h, t, init, wc, sc,
-        enabled ? EndpointReuse::Deterministic : EndpointReuse::Disabled);
+    AdaptiveWalnuts a(rng, h, t, init, wc, sc);
     h.after_warmup = [&] {
       t.offset += 100;
       a.invalidate_endpoint_cache();
     };
     for (int i = 0; i < 3; ++i) {
-      a();
+      draw_with_reuse(a, enabled);
     }
     auto sampler = a.sampler();
-    sampler();
+    draw_with_reuse(sampler, enabled);
     traces[enabled] = h.trace;
     counts[enabled] = t.calls;
   }
@@ -275,10 +276,8 @@ TEST(EndpointReuse, FreezeCallbackInvalidationAndOrdering) {
     auto init = InitChainConfig(0.2, zero(), ones());
     auto wc = WarmupConfigBuilder().build();
     auto sc = sampling_config();
-    AdaptiveWalnuts a(
-        rng, h, t, init, wc, sc,
-        enabled ? EndpointReuse::Deterministic : EndpointReuse::Disabled);
-    a();
+    AdaptiveWalnuts a(rng, h, t, init, wc, sc);
+    draw_with_reuse(a, enabled);
     auto before = t.calls;
     h.after_freeze = [&] {
       EXPECT_EQ(t.calls, before);
@@ -287,7 +286,7 @@ TEST(EndpointReuse, FreezeCallbackInvalidationAndOrdering) {
     };
     auto s = a.sampler();
     EXPECT_EQ(t.calls, before);
-    s();
+    draw_with_reuse(s, enabled);
     // Each call delivers a completion event, just as upstream does.
     before = t.calls;
     auto unused = a.sampler();
@@ -304,8 +303,7 @@ TEST(EndpointReuse, CopyMoveValueOwnership) {
     Target t;
     Handler h;
     std::mt19937_64 rng(17);
-    WalnutsSampler original(rng, h, t, zero(), ones(), 0.2, 4, 8, 1, 1.0,
-                            EndpointReuse::Deterministic);
+    WalnutsSampler original(rng, h, t, zero(), ones(), 0.2, 4, 8, 1, 1.0);
     if (populated) {
       original();
     }
@@ -348,7 +346,7 @@ TEST(EndpointReuse, AdaptiveCopyMoveAndIndependentFreeze) {
     auto init = InitChainConfig(0.2, zero(), ones());
     auto wc = WarmupConfigBuilder().build();
     auto sc = sampling_config();
-    AdaptiveWalnuts a(rng, h, t, init, wc, sc, EndpointReuse::Deterministic);
+    AdaptiveWalnuts a(rng, h, t, init, wc, sc);
     if (populated) {
       a();
     }
@@ -403,29 +401,54 @@ TEST(EndpointReuse, WrongSizedCacheFallsBack) {
   std::mt19937_64 rng(17);
   detail::Random random(rng);
   detail::NoOpStepSizeAdapter adapter;
-  detail::EndpointCache cache;
-  cache.store(Eigen::VectorXd::Ones(3), 999.0);
+  Eigen::VectorXd wrong_gradient = Eigen::VectorXd::Ones(3);
   std::size_t depth;
   Eigen::VectorXd grad;
   double lp;
-  auto theta =
-      detail::transition_w_impl(random, t, ones(), ones(), 0.1, 1, 1, 1, 1.0,
-                                zero(), depth, grad, lp, adapter, &cache);
+  auto theta = detail::transition_w_impl(random, t, ones(), ones(), 0.1, 1, 1,
+                                         1, 1.0, zero(), depth, grad, lp,
+                                         adapter, &wrong_gradient, 999.0);
   EXPECT_EQ(t.calls, 2);
   EXPECT_EQ(grad.size(), theta.size());
   EXPECT_LE(lp, 0);
 }
 
-TEST(EndpointReuse, ExplicitValidityAndFiniteCache) {
-  detail::EndpointCache c;
-  EXPECT_FALSE(c.valid);
-  c.store(Eigen::VectorXd(), 0.0);
-  EXPECT_TRUE(c.valid);
-  c.store(ones(), std::numeric_limits<double>::infinity());
-  EXPECT_FALSE(c.valid);
-  c.store(
-      Eigen::VectorXd::Constant(2, std::numeric_limits<double>::quiet_NaN()),
-      0.0);
-  EXPECT_FALSE(c.valid);
+struct MutatingDensityHandler : Handler {
+  void on_sample(const Eigen::VectorXd& x, double& lp) {
+    Handler::on_sample(x, lp);
+    lp = 12345;
+  }
+  void on_warmup(const Eigen::VectorXd& x, double& lp, double step,
+                 const Eigen::VectorXd& mass) {
+    Handler::on_warmup(x, lp, step, mass);
+    lp = 12345;
+  }
+};
+TEST(EndpointReuse, CallbackDensityReferenceDoesNotChangeStoredEndpoint) {
+  Bits traces[2];
+  std::mt19937_64 states[2];
+  std::size_t counts[2];
+  for (bool reuse : {false, true}) {
+    Target target;
+    MutatingDensityHandler handler;
+    std::mt19937_64 rng(17);
+    auto init = InitChainConfig(.2, zero(), ones());
+    auto warmup = WarmupConfigBuilder().build();
+    auto config = sampling_config();
+    AdaptiveWalnuts adaptive(rng, handler, target, init, warmup, config);
+    for (int i = 0; i < 20; ++i) {
+      draw_with_reuse(adaptive, reuse);
+    }
+    auto sampler = adaptive.sampler();
+    for (int i = 0; i < 20; ++i) {
+      EXPECT_EQ(draw_with_reuse(sampler, reuse), 12345);
+    }
+    traces[reuse] = handler.trace;
+    states[reuse] = rng;
+    counts[reuse] = target.calls;
+  }
+  EXPECT_EQ(traces[0], traces[1]);
+  EXPECT_EQ(states[0], states[1]);
+  EXPECT_EQ(counts[0] - counts[1], 39);
 }
 }  // namespace

--- a/tests/endpoint_test.cpp
+++ b/tests/endpoint_test.cpp
@@ -1,0 +1,431 @@
+#include <gtest/gtest.h>
+#include <bit>
+#include <cstdint>
+#include <functional>
+#include <vector>
+#include <walnutpie/adaptive_walnuts.hpp>
+
+namespace {
+using namespace walnutpie;
+using Bits = std::vector<std::uint64_t>;
+struct Target {
+  int kind = 0;
+  mutable std::size_t calls = 0;
+  int failure = 0;
+  double offset = 0;
+  void operator()(const Eigen::VectorXd& x, double& lp,
+                  Eigen::VectorXd& g) const {
+    ++calls;
+    if (failure == 1 || (failure == 4 && x.squaredNorm() > 0)) {
+      throw std::runtime_error("test failure");
+    }
+    if (kind == 0) {
+      lp = -0.5 * x.squaredNorm();
+      g = -x;
+    }
+    if (kind == 1) {
+      lp = -0.5 * (2 * x[0] * x[0] + 2 * x[0] * x[1] + 3 * x[1] * x[1]);
+      g.resize(2);
+      g << -2 * x[0] - x[1], -x[0] - 3 * x[1];
+    }
+    if (kind == 2) {
+      lp = -0.5 * x.squaredNorm() - 0.25 * x.array().pow(4).sum();
+      g = -x.array() - x.array().cube();
+    }
+    lp += offset;
+    if (failure == 2) {
+      lp = -std::numeric_limits<double>::infinity();
+    }
+    if (failure == 3) {
+      g.setConstant(std::numeric_limits<double>::quiet_NaN());
+    }
+  }
+};
+struct Handler {
+  Bits trace;
+  std::size_t errors = 0, warmups = 0, samples = 0, freezes = 0;
+  std::function<void()> after_sample, after_warmup, after_freeze;
+  void add(double v) { trace.push_back(std::bit_cast<std::uint64_t>(v)); }
+  void add(const Eigen::VectorXd& x) {
+    for (double v : x) {
+      add(v);
+    }
+  }
+  void on_sample(const Eigen::VectorXd& x, double lp) {
+    trace.push_back(1);
+    add(x);
+    add(lp);
+    ++samples;
+    if (after_sample) {
+      after_sample();
+    }
+  }
+  void on_warmup(const Eigen::VectorXd& x, double lp, double step,
+                 const Eigen::VectorXd& mass) {
+    trace.push_back(2);
+    add(x);
+    add(lp);
+    add(step);
+    add(mass);
+    ++warmups;
+    if (after_warmup) {
+      after_warmup();
+    }
+  }
+  void on_warmup_complete(double step, const Eigen::VectorXd& mass) {
+    trace.push_back(3);
+    add(step);
+    add(mass);
+    ++freezes;
+    if (after_freeze) {
+      after_freeze();
+    }
+  }
+  void on_logp_exception(const Eigen::VectorXd&,
+                         const std::exception&) noexcept {
+    ++errors;
+  }
+};
+Eigen::VectorXd zero() { return Eigen::VectorXd::Zero(2); }
+Eigen::VectorXd ones() { return Eigen::VectorXd::Ones(2); }
+auto sampling_config() {
+  return SamplingConfigBuilder()
+      .max_trajectory_doublings(4)
+      .max_step_halvings(8)
+      .build();
+}
+struct Run {
+  Bits trace;
+  std::size_t calls;
+};
+Run chain(int kind, unsigned seed, EndpointReuse policy, int warmup = 100) {
+  Target t{kind};
+  Handler h;
+  std::mt19937_64 rng(seed);
+  auto init = InitChainConfig(0.2, zero(), ones());
+  auto wc = WarmupConfigBuilder().build();
+  auto sc = sampling_config();
+  AdaptiveWalnuts a(rng, h, t, init, wc, sc, policy);
+  for (int i = 0; i < warmup; ++i) {
+    a();
+  }
+  auto before = t.calls;
+  auto sampler = a.sampler();
+  EXPECT_EQ(before, t.calls);
+  for (int i = 0; i < 100; ++i) {
+    auto lp = sampler();
+    EXPECT_EQ(std::bit_cast<std::uint64_t>(lp), h.trace.back());
+  }
+  EXPECT_EQ(h.warmups, warmup);
+  EXPECT_EQ(h.samples, 100);
+  EXPECT_EQ(h.freezes, 1);
+  EXPECT_EQ(h.errors, 0);
+  return {h.trace, t.calls};
+}
+TEST(EndpointReuse, AnalyticParityAndCounts) {
+  for (int kind = 0; kind < 3; ++kind) {
+    for (unsigned seed : {17u, 20260819u}) {
+      auto off = chain(kind, seed, EndpointReuse::Disabled);
+      auto on = chain(kind, seed, EndpointReuse::Deterministic);
+      EXPECT_EQ(off.trace, on.trace);
+      EXPECT_EQ(off.calls - on.calls, 199);
+      std::cout << "endpoint kind=" << kind << " seed=" << seed
+                << " baseline=" << off.calls << " cached=" << on.calls << "\n";
+    }
+  }
+}
+TEST(EndpointReuse, ZeroWarmupAndColdSampler) {
+  auto off = chain(0, 17, EndpointReuse::Disabled, 0);
+  auto on = chain(0, 17, EndpointReuse::Deterministic, 0);
+  EXPECT_EQ(off.trace, on.trace);
+  EXPECT_EQ(off.calls - on.calls, 99);
+  std::size_t calls[2];
+  Bits traces[2];
+  for (int enabled = 0; enabled < 2; ++enabled) {
+    Target t;
+    Handler h;
+    std::mt19937_64 rng(17);
+    WalnutsSampler s(
+        rng, h, t, zero(), ones(), 0.2, 4, 8, 1, 1.0,
+        enabled ? EndpointReuse::Deterministic : EndpointReuse::Disabled);
+    for (int i = 0; i < 100; ++i) {
+      s();
+    }
+    calls[enabled] = t.calls;
+    traces[enabled] = h.trace;
+  }
+  EXPECT_EQ(traces[0], traces[1]);
+  EXPECT_EQ(calls[0] - calls[1], 99);
+}
+TEST(EndpointReuse, InvalidEndpointsRetryAndRecover) {
+  for (int failure : {1, 2, 3}) {
+    std::size_t calls[2], errors[2];
+    Bits traces[2];
+    for (int enabled = 0; enabled < 2; ++enabled) {
+      Target t;
+      t.failure = failure;
+      Handler h;
+      std::mt19937_64 rng(17);
+      WalnutsSampler s(
+          rng, h, t, zero(), ones(), 0.1, 1, 1, 1, 1.0,
+          enabled ? EndpointReuse::Deterministic : EndpointReuse::Disabled);
+      for (int i = 0; i < 3; ++i) {
+        s();
+      }
+      EXPECT_EQ(t.calls, 6);
+      EXPECT_EQ(h.errors, failure == 1 ? 6 : 0);
+      t.failure = 0;  // invalid endpoints must not prevent retry/recovery
+      s();
+      EXPECT_EQ(t.calls, 8);
+      s();
+      calls[enabled] = t.calls;
+      errors[enabled] = h.errors;
+      traces[enabled] = h.trace;
+    }
+    EXPECT_EQ(traces[0], traces[1]);
+    EXPECT_EQ(errors[0], errors[1]);
+    EXPECT_EQ(calls[0] - calls[1], 1);
+  }
+}
+TEST(EndpointReuse, RejectedTrajectoryKeepsFiniteEndpoint) {
+  Bits traces[2];
+  for (int enabled = 0; enabled < 2; ++enabled) {
+    Target t;
+    t.failure = 4;
+    Handler h;
+    std::mt19937_64 rng(17);
+    WalnutsSampler s(
+        rng, h, t, zero(), ones(), 0.1, 1, 1, 1, 1.0,
+        enabled ? EndpointReuse::Deterministic : EndpointReuse::Disabled);
+    for (int i = 0; i < 3; ++i) {
+      s();
+    }
+    EXPECT_EQ(t.calls, enabled ? 4 : 6);
+    EXPECT_EQ(h.errors, 3);
+    EXPECT_EQ(h.samples, 3);
+    traces[enabled] = h.trace;
+  }
+  EXPECT_EQ(traces[0], traces[1]);
+}
+TEST(EndpointReuse, InvalidationAndDefaultMutableTarget) {
+  Bits traces[2];
+  std::size_t counts[2];
+  for (int enabled = 0; enabled < 2; ++enabled) {
+    Target t;
+    Handler h;
+    std::mt19937_64 rng(17);
+    // The default constructor API remains valid.
+    WalnutsSampler plain(rng, h, t, zero(), ones(), 0.1, 1, 1, 1, 1.0);
+    WalnutsSampler cached(rng, h, t, zero(), ones(), 0.1, 1, 1, 1, 1.0,
+                          EndpointReuse::Deterministic);
+    h.after_sample = [&] {
+      t.offset += 100;
+      cached.invalidate_endpoint_cache();
+    };
+    for (int i = 0; i < 3; ++i) {
+      if (enabled) {
+        cached();
+      } else {
+        plain();
+      }
+    }
+    counts[enabled] = t.calls;
+    traces[enabled] = h.trace;
+  }
+  EXPECT_EQ(counts[0], 6);
+  EXPECT_EQ(counts[0], counts[1]);
+  EXPECT_EQ(traces[0], traces[1]);
+}
+TEST(EndpointReuse, WarmupCallbackInvalidation) {
+  Bits traces[2];
+  std::size_t counts[2];
+  for (int enabled = 0; enabled < 2; ++enabled) {
+    Target t;
+    Handler h;
+    std::mt19937_64 rng(17);
+    auto init = InitChainConfig(0.2, zero(), ones());
+    auto wc = WarmupConfigBuilder().build();
+    auto sc = sampling_config();
+    AdaptiveWalnuts a(
+        rng, h, t, init, wc, sc,
+        enabled ? EndpointReuse::Deterministic : EndpointReuse::Disabled);
+    h.after_warmup = [&] {
+      t.offset += 100;
+      a.invalidate_endpoint_cache();
+    };
+    for (int i = 0; i < 3; ++i) {
+      a();
+    }
+    auto sampler = a.sampler();
+    sampler();
+    traces[enabled] = h.trace;
+    counts[enabled] = t.calls;
+  }
+  EXPECT_EQ(traces[0], traces[1]);
+  EXPECT_EQ(counts[0], counts[1]);
+}
+
+TEST(EndpointReuse, FreezeCallbackInvalidationAndOrdering) {
+  Bits traces[2];
+  std::size_t counts[2];
+  for (int enabled = 0; enabled < 2; ++enabled) {
+    Target t;
+    Handler h;
+    std::mt19937_64 rng(17);
+    auto init = InitChainConfig(0.2, zero(), ones());
+    auto wc = WarmupConfigBuilder().build();
+    auto sc = sampling_config();
+    AdaptiveWalnuts a(
+        rng, h, t, init, wc, sc,
+        enabled ? EndpointReuse::Deterministic : EndpointReuse::Disabled);
+    a();
+    auto before = t.calls;
+    h.after_freeze = [&] {
+      EXPECT_EQ(t.calls, before);
+      t.offset += 100;
+      a.invalidate_endpoint_cache();
+    };
+    auto s = a.sampler();
+    EXPECT_EQ(t.calls, before);
+    s();
+    // Each call delivers a completion event, just as upstream does.
+    before = t.calls;
+    auto unused = a.sampler();
+    EXPECT_EQ(h.freezes, 2);
+    EXPECT_EQ(t.calls, before);
+    counts[enabled] = t.calls;
+    traces[enabled] = h.trace;
+  }
+  EXPECT_EQ(traces[0], traces[1]);
+  EXPECT_EQ(counts[0], counts[1]);
+}
+TEST(EndpointReuse, CopyMoveValueOwnership) {
+  for (bool populated : {false, true}) {
+    Target t;
+    Handler h;
+    std::mt19937_64 rng(17);
+    WalnutsSampler original(rng, h, t, zero(), ones(), 0.2, 4, 8, 1, 1.0,
+                            EndpointReuse::Deterministic);
+    if (populated) {
+      original();
+    }
+    auto copy = original;
+    auto moved = std::move(copy);
+    auto state = rng;
+    h.trace.clear();
+    auto before = t.calls;
+    original();
+    auto trace = h.trace;
+    auto calls = t.calls - before;
+    rng = state;
+    h.trace.clear();
+    before = t.calls;
+    moved();
+    EXPECT_EQ(trace, h.trace);
+    EXPECT_EQ(calls, t.calls - before);
+    // Invalidating one copy must not clear the other's populated cache.
+    auto twin = moved;
+    moved.invalidate_endpoint_cache();
+    state = rng;
+    h.trace.clear();
+    before = t.calls;
+    moved();
+    trace = h.trace;
+    calls = t.calls - before;
+    rng = state;
+    h.trace.clear();
+    before = t.calls;
+    twin();
+    EXPECT_EQ(trace, h.trace);
+    EXPECT_EQ(calls, t.calls - before + 1);
+  }
+}
+TEST(EndpointReuse, AdaptiveCopyMoveAndIndependentFreeze) {
+  for (bool populated : {false, true}) {
+    Target t;
+    Handler h;
+    std::mt19937_64 rng(17);
+    auto init = InitChainConfig(0.2, zero(), ones());
+    auto wc = WarmupConfigBuilder().build();
+    auto sc = sampling_config();
+    AdaptiveWalnuts a(rng, h, t, init, wc, sc, EndpointReuse::Deterministic);
+    if (populated) {
+      a();
+    }
+    auto copy = a;
+    auto moved = std::move(copy);
+    auto state = rng;
+    h.trace.clear();
+    auto before = t.calls;
+    a();
+    auto trace = h.trace;
+    auto calls = t.calls - before;
+    rng = state;
+    h.trace.clear();
+    before = t.calls;
+    moved();
+    EXPECT_EQ(trace, h.trace);
+    EXPECT_EQ(calls, t.calls - before);
+    auto s = a.sampler();
+    auto twin = moved.sampler();
+    a.invalidate_endpoint_cache();
+    state = rng;
+    h.trace.clear();
+    before = t.calls;
+    s();
+    trace = h.trace;
+    calls = t.calls - before;
+    rng = state;
+    h.trace.clear();
+    before = t.calls;
+    twin();
+    EXPECT_EQ(trace, h.trace);
+    EXPECT_EQ(calls, t.calls - before);
+  }
+}
+TEST(EndpointReuse, LegacyTransitionEntryPoint) {
+  Target t;
+  std::mt19937_64 rng(17);
+  detail::Random random(rng);
+  detail::NoOpStepSizeAdapter adapter;
+  std::size_t depth;
+  Eigen::VectorXd grad;
+  double lp;
+  auto theta = detail::transition_w(random, t, ones(), ones(), 0.1, 1, 1, 1,
+                                    1.0, zero(), depth, grad, lp, adapter);
+  EXPECT_EQ(t.calls, 2);
+  EXPECT_EQ(grad.size(), theta.size());
+  EXPECT_TRUE(std::isfinite(lp));
+}
+
+TEST(EndpointReuse, WrongSizedCacheFallsBack) {
+  Target t;
+  std::mt19937_64 rng(17);
+  detail::Random random(rng);
+  detail::NoOpStepSizeAdapter adapter;
+  detail::EndpointCache cache;
+  cache.store(Eigen::VectorXd::Ones(3), 999.0);
+  std::size_t depth;
+  Eigen::VectorXd grad;
+  double lp;
+  auto theta =
+      detail::transition_w_impl(random, t, ones(), ones(), 0.1, 1, 1, 1, 1.0,
+                                zero(), depth, grad, lp, adapter, &cache);
+  EXPECT_EQ(t.calls, 2);
+  EXPECT_EQ(grad.size(), theta.size());
+  EXPECT_LE(lp, 0);
+}
+
+TEST(EndpointReuse, ExplicitValidityAndFiniteCache) {
+  detail::EndpointCache c;
+  EXPECT_FALSE(c.valid);
+  c.store(Eigen::VectorXd(), 0.0);
+  EXPECT_TRUE(c.valid);
+  c.store(ones(), std::numeric_limits<double>::infinity());
+  EXPECT_FALSE(c.valid);
+  c.store(
+      Eigen::VectorXd::Constant(2, std::numeric_limits<double>::quiet_NaN()),
+      0.0);
+  EXPECT_FALSE(c.valid);
+}
+}  // namespace

--- a/tests/endpoint_test.cpp
+++ b/tests/endpoint_test.cpp
@@ -1,454 +1,131 @@
 #include <gtest/gtest.h>
-#include <bit>
-#include <cstdint>
-#include <functional>
+
+#include <Eigen/Dense>
+#include <random>
+#include <stdexcept>
+#include <utility>
 #include <vector>
+
 #include <walnutpie/adaptive_walnuts.hpp>
 
 namespace {
+
 using namespace walnutpie;
-using Bits = std::vector<std::uint64_t>;
+
+// Standard normal target that counts evaluations and can fail away from the
+// origin.
 struct Target {
-  int kind = 0;
   mutable std::size_t calls = 0;
-  int failure = 0;
-  double offset = 0;
+  mutable Eigen::VectorXd last_evaluated;
+  mutable bool fail_away_from_origin = false;
   void operator()(const Eigen::VectorXd& x, double& lp,
                   Eigen::VectorXd& g) const {
     ++calls;
-    if (failure == 1 || (failure == 4 && x.squaredNorm() > 0)) {
+    last_evaluated = x;
+    if (fail_away_from_origin && x.squaredNorm() > 0) {
       throw std::runtime_error("test failure");
     }
-    if (kind == 0) {
-      lp = -0.5 * x.squaredNorm();
-      g = -x;
-    }
-    if (kind == 1) {
-      lp = -0.5 * (2 * x[0] * x[0] + 2 * x[0] * x[1] + 3 * x[1] * x[1]);
-      g.resize(2);
-      g << -2 * x[0] - x[1], -x[0] - 3 * x[1];
-    }
-    if (kind == 2) {
-      lp = -0.5 * x.squaredNorm() - 0.25 * x.array().pow(4).sum();
-      g = -x.array() - x.array().cube();
-    }
-    lp += offset;
-    if (failure == 2) {
-      lp = -std::numeric_limits<double>::infinity();
-    }
-    if (failure == 3) {
-      g.setConstant(std::numeric_limits<double>::quiet_NaN());
-    }
+    lp = -0.5 * x.squaredNorm();
+    g = -x;
   }
 };
+
+// Records sampled draws, the last warmup position, and target failures.
 struct Handler {
-  Bits trace;
-  std::size_t errors = 0, warmups = 0, samples = 0, freezes = 0;
-  std::function<void()> after_sample, after_warmup, after_freeze;
-  void add(double v) { trace.push_back(std::bit_cast<std::uint64_t>(v)); }
-  void add(const Eigen::VectorXd& x) {
-    for (double v : x) {
-      add(v);
-    }
-  }
+  std::vector<std::pair<Eigen::VectorXd, double>> samples;
+  Eigen::VectorXd last_warmup;
+  std::size_t errors = 0;
   void on_sample(const Eigen::VectorXd& x, double lp) {
-    trace.push_back(1);
-    add(x);
-    add(lp);
-    ++samples;
-    if (after_sample) {
-      after_sample();
-    }
+    samples.emplace_back(x, lp);
   }
-  void on_warmup(const Eigen::VectorXd& x, double lp, double step,
-                 const Eigen::VectorXd& mass) {
-    trace.push_back(2);
-    add(x);
-    add(lp);
-    add(step);
-    add(mass);
-    ++warmups;
-    if (after_warmup) {
-      after_warmup();
-    }
+  void on_warmup(const Eigen::VectorXd& x, double, double,
+                 const Eigen::VectorXd&) {
+    last_warmup = x;
   }
-  void on_warmup_complete(double step, const Eigen::VectorXd& mass) {
-    trace.push_back(3);
-    add(step);
-    add(mass);
-    ++freezes;
-    if (after_freeze) {
-      after_freeze();
-    }
-  }
+  void on_warmup_complete(double, const Eigen::VectorXd&) {}
   void on_logp_exception(const Eigen::VectorXd&,
                          const std::exception&) noexcept {
     ++errors;
   }
 };
+
+using Sampler = WalnutsSampler<Target, std::mt19937_64, Handler>;
+
 Eigen::VectorXd zero() { return Eigen::VectorXd::Zero(2); }
 Eigen::VectorXd ones() { return Eigen::VectorXd::Ones(2); }
-auto sampling_config() {
-  return SamplingConfigBuilder()
-      .max_trajectory_doublings(4)
-      .max_step_halvings(8)
-      .build();
-}
-template <typename S>
-auto draw_with_reuse(S& sampler, bool reuse = true) {
-  if (!reuse) {
-    sampler.invalidate_endpoint_cache();
-  }
-  return sampler();
-}
-struct Run {
-  Bits trace;
-  std::size_t calls;
-  std::mt19937_64 rng;
-};
-Run chain(int kind, unsigned seed, bool reuse, int warmup = 100) {
-  Target t{kind};
-  Handler h;
-  std::mt19937_64 rng(seed);
-  auto init = InitChainConfig(0.2, zero(), ones());
-  auto wc = WarmupConfigBuilder().build();
-  auto sc = sampling_config();
-  AdaptiveWalnuts a(rng, h, t, init, wc, sc);
-  for (int i = 0; i < warmup; ++i) {
-    draw_with_reuse(a, reuse);
-  }
-  auto before = t.calls;
-  auto sampler = a.sampler();
-  EXPECT_EQ(before, t.calls);
-  for (int i = 0; i < 100; ++i) {
-    auto lp = draw_with_reuse(sampler, reuse);
-    EXPECT_EQ(std::bit_cast<std::uint64_t>(lp), h.trace.back());
-  }
-  EXPECT_EQ(h.warmups, warmup);
-  EXPECT_EQ(h.samples, 100);
-  EXPECT_EQ(h.freezes, 1);
-  EXPECT_EQ(h.errors, 0);
-  return {h.trace, t.calls, rng};
-}
-TEST(EndpointReuse, AnalyticParityAndCounts) {
-  for (int kind = 0; kind < 3; ++kind) {
-    for (unsigned seed : {17u, 20260819u}) {
-      auto off = chain(kind, seed, false);
-      auto on = chain(kind, seed, true);
-      EXPECT_EQ(off.trace, on.trace);
-      EXPECT_EQ(off.rng, on.rng);
-      EXPECT_EQ(off.calls - on.calls, 199);
-      std::cout << "endpoint kind=" << kind << " seed=" << seed
-                << " baseline=" << off.calls << " cached=" << on.calls << "\n";
+
+// A fresh sampler built at the previous draw re-evaluates the endpoint in
+// its constructor: an uncached baseline. The persistent sampler must give
+// the same chain, with one evaluation saved per draw.
+TEST(EndpointReuse, MatchesUncachedBaselineAndSavesOneEvaluationPerDraw) {
+  for (unsigned seed : {17u, 20260910u}) {
+    Target cached_target, baseline_target;
+    Handler cached_handler, baseline_handler;
+    std::mt19937_64 cached_rng(seed), baseline_rng(seed);
+    Sampler cached(cached_rng, cached_handler, cached_target, zero(), ones(),
+                   0.2, 4, 8, 1, 1.0);
+    EXPECT_EQ(cached_target.calls, 1);  // evaluated once at construction
+
+    Eigen::VectorXd position = zero();
+    for (int i = 0; i < 50; ++i) {
+      Sampler baseline(baseline_rng, baseline_handler, baseline_target,
+                       position, ones(), 0.2, 4, 8, 1, 1.0);
+      baseline();
+      position = baseline_handler.samples.back().first;
     }
-  }
-}
-TEST(EndpointReuse, ZeroWarmupAndColdSampler) {
-  auto off = chain(0, 17, false, 0);
-  auto on = chain(0, 17, true, 0);
-  EXPECT_EQ(off.trace, on.trace);
-  EXPECT_EQ(off.rng, on.rng);
-  EXPECT_EQ(off.calls - on.calls, 99);
-  std::size_t calls[2];
-  Bits traces[2];
-  for (int enabled = 0; enabled < 2; ++enabled) {
-    Target t;
-    Handler h;
-    std::mt19937_64 rng(17);
-    WalnutsSampler s(rng, h, t, zero(), ones(), 0.2, 4, 8, 1, 1.0);
-    for (int i = 0; i < 100; ++i) {
-      draw_with_reuse(s, enabled);
+
+    for (int i = 0; i < 50; ++i) {
+      cached();
     }
-    calls[enabled] = t.calls;
-    traces[enabled] = h.trace;
+    EXPECT_EQ(cached_handler.samples, baseline_handler.samples);
+    EXPECT_EQ(cached_rng, baseline_rng);
+    EXPECT_EQ(baseline_target.calls - cached_target.calls, 49);
   }
-  EXPECT_EQ(traces[0], traces[1]);
-  EXPECT_EQ(calls[0] - calls[1], 99);
-}
-TEST(EndpointReuse, InvalidEndpointsRetryAndRecover) {
-  for (int failure : {1, 2, 3}) {
-    std::size_t calls[2], errors[2];
-    Bits traces[2];
-    for (int enabled = 0; enabled < 2; ++enabled) {
-      Target t;
-      t.failure = failure;
-      Handler h;
-      std::mt19937_64 rng(17);
-      WalnutsSampler s(rng, h, t, zero(), ones(), 0.1, 1, 1, 1, 1.0);
-      for (int i = 0; i < 3; ++i) {
-        draw_with_reuse(s, enabled);
-      }
-      EXPECT_EQ(t.calls, 6);
-      EXPECT_EQ(h.errors, failure == 1 ? 6 : 0);
-      t.failure = 0;  // invalid endpoints must not prevent retry/recovery
-      draw_with_reuse(s, enabled);
-      EXPECT_EQ(t.calls, 8);
-      draw_with_reuse(s, enabled);
-      calls[enabled] = t.calls;
-      errors[enabled] = h.errors;
-      traces[enabled] = h.trace;
-    }
-    EXPECT_EQ(traces[0], traces[1]);
-    EXPECT_EQ(errors[0], errors[1]);
-    EXPECT_EQ(calls[0] - calls[1], 1);
-  }
-}
-TEST(EndpointReuse, RejectedTrajectoryKeepsFiniteEndpoint) {
-  Bits traces[2];
-  for (int enabled = 0; enabled < 2; ++enabled) {
-    Target t;
-    t.failure = 4;
-    Handler h;
-    std::mt19937_64 rng(17);
-    WalnutsSampler s(rng, h, t, zero(), ones(), 0.1, 1, 1, 1, 1.0);
-    for (int i = 0; i < 3; ++i) {
-      draw_with_reuse(s, enabled);
-    }
-    EXPECT_EQ(t.calls, enabled ? 4 : 6);
-    EXPECT_EQ(h.errors, 3);
-    EXPECT_EQ(h.samples, 3);
-    traces[enabled] = h.trace;
-  }
-  EXPECT_EQ(traces[0], traces[1]);
-}
-TEST(EndpointReuse, InvalidationAndDefaultMutableTarget) {
-  Bits traces[2];
-  std::size_t counts[2];
-  for (int enabled = 0; enabled < 2; ++enabled) {
-    Target t;
-    Handler h;
-    std::mt19937_64 rng(17);
-    // The default constructor API remains valid.
-    WalnutsSampler plain(rng, h, t, zero(), ones(), 0.1, 1, 1, 1, 1.0);
-    WalnutsSampler cached(rng, h, t, zero(), ones(), 0.1, 1, 1, 1, 1.0);
-    h.after_sample = [&] {
-      t.offset += 100;
-      cached.invalidate_endpoint_cache();
-    };
-    for (int i = 0; i < 3; ++i) {
-      if (enabled) {
-        cached();
-      } else {
-        draw_with_reuse(plain, false);
-      }
-    }
-    counts[enabled] = t.calls;
-    traces[enabled] = h.trace;
-  }
-  EXPECT_EQ(counts[0], 6);
-  EXPECT_EQ(counts[0], counts[1]);
-  EXPECT_EQ(traces[0], traces[1]);
-}
-TEST(EndpointReuse, WarmupCallbackInvalidation) {
-  Bits traces[2];
-  std::size_t counts[2];
-  for (int enabled = 0; enabled < 2; ++enabled) {
-    Target t;
-    Handler h;
-    std::mt19937_64 rng(17);
-    auto init = InitChainConfig(0.2, zero(), ones());
-    auto wc = WarmupConfigBuilder().build();
-    auto sc = sampling_config();
-    AdaptiveWalnuts a(rng, h, t, init, wc, sc);
-    h.after_warmup = [&] {
-      t.offset += 100;
-      a.invalidate_endpoint_cache();
-    };
-    for (int i = 0; i < 3; ++i) {
-      draw_with_reuse(a, enabled);
-    }
-    auto sampler = a.sampler();
-    draw_with_reuse(sampler, enabled);
-    traces[enabled] = h.trace;
-    counts[enabled] = t.calls;
-  }
-  EXPECT_EQ(traces[0], traces[1]);
-  EXPECT_EQ(counts[0], counts[1]);
 }
 
-TEST(EndpointReuse, FreezeCallbackInvalidationAndOrdering) {
-  Bits traces[2];
-  std::size_t counts[2];
-  for (int enabled = 0; enabled < 2; ++enabled) {
-    Target t;
-    Handler h;
-    std::mt19937_64 rng(17);
-    auto init = InitChainConfig(0.2, zero(), ones());
-    auto wc = WarmupConfigBuilder().build();
-    auto sc = sampling_config();
-    AdaptiveWalnuts a(rng, h, t, init, wc, sc);
-    draw_with_reuse(a, enabled);
-    auto before = t.calls;
-    h.after_freeze = [&] {
-      EXPECT_EQ(t.calls, before);
-      t.offset += 100;
-      a.invalidate_endpoint_cache();
-    };
-    auto s = a.sampler();
-    EXPECT_EQ(t.calls, before);
-    draw_with_reuse(s, enabled);
-    // Each call delivers a completion event, just as upstream does.
-    before = t.calls;
-    auto unused = a.sampler();
-    EXPECT_EQ(h.freezes, 2);
-    EXPECT_EQ(t.calls, before);
-    counts[enabled] = t.calls;
-    traces[enabled] = h.trace;
-  }
-  EXPECT_EQ(traces[0], traces[1]);
-  EXPECT_EQ(counts[0], counts[1]);
-}
-TEST(EndpointReuse, CopyMoveValueOwnership) {
-  for (bool populated : {false, true}) {
-    Target t;
-    Handler h;
-    std::mt19937_64 rng(17);
-    WalnutsSampler original(rng, h, t, zero(), ones(), 0.2, 4, 8, 1, 1.0);
-    if (populated) {
-      original();
-    }
-    auto copy = original;
-    auto moved = std::move(copy);
-    auto state = rng;
-    h.trace.clear();
-    auto before = t.calls;
-    original();
-    auto trace = h.trace;
-    auto calls = t.calls - before;
-    rng = state;
-    h.trace.clear();
-    before = t.calls;
-    moved();
-    EXPECT_EQ(trace, h.trace);
-    EXPECT_EQ(calls, t.calls - before);
-    // Invalidating one copy must not clear the other's populated cache.
-    auto twin = moved;
-    moved.invalidate_endpoint_cache();
-    state = rng;
-    h.trace.clear();
-    before = t.calls;
-    moved();
-    trace = h.trace;
-    calls = t.calls - before;
-    rng = state;
-    h.trace.clear();
-    before = t.calls;
-    twin();
-    EXPECT_EQ(trace, h.trace);
-    EXPECT_EQ(calls, t.calls - before + 1);
-  }
-}
-TEST(EndpointReuse, AdaptiveCopyMoveAndIndependentFreeze) {
-  for (bool populated : {false, true}) {
-    Target t;
-    Handler h;
-    std::mt19937_64 rng(17);
-    auto init = InitChainConfig(0.2, zero(), ones());
-    auto wc = WarmupConfigBuilder().build();
-    auto sc = sampling_config();
-    AdaptiveWalnuts a(rng, h, t, init, wc, sc);
-    if (populated) {
-      a();
-    }
-    auto copy = a;
-    auto moved = std::move(copy);
-    auto state = rng;
-    h.trace.clear();
-    auto before = t.calls;
-    a();
-    auto trace = h.trace;
-    auto calls = t.calls - before;
-    rng = state;
-    h.trace.clear();
-    before = t.calls;
-    moved();
-    EXPECT_EQ(trace, h.trace);
-    EXPECT_EQ(calls, t.calls - before);
-    auto s = a.sampler();
-    auto twin = moved.sampler();
-    a.invalidate_endpoint_cache();
-    state = rng;
-    h.trace.clear();
-    before = t.calls;
-    s();
-    trace = h.trace;
-    calls = t.calls - before;
-    rng = state;
-    h.trace.clear();
-    before = t.calls;
-    twin();
-    EXPECT_EQ(trace, h.trace);
-    EXPECT_EQ(calls, t.calls - before);
-  }
-}
-TEST(EndpointReuse, LegacyTransitionEntryPoint) {
-  Target t;
+// While the target fails away from the origin, each draw keeps the stored
+// endpoint and costs only the failed trajectory evaluations (1 + 2 + 4 with
+// one doubling and three halvings). After the target recovers, the chain
+// moves on.
+TEST(EndpointReuse, FailuresKeepStoredEndpointUntilRecovery) {
+  Target target;
+  target.fail_away_from_origin = true;
+  Handler handler;
   std::mt19937_64 rng(17);
-  detail::Random random(rng);
-  detail::NoOpStepSizeAdapter adapter;
-  std::size_t depth;
-  Eigen::VectorXd grad;
-  double lp;
-  auto theta = detail::transition_w(random, t, ones(), ones(), 0.1, 1, 1, 1,
-                                    1.0, zero(), depth, grad, lp, adapter);
-  EXPECT_EQ(t.calls, 2);
-  EXPECT_EQ(grad.size(), theta.size());
-  EXPECT_TRUE(std::isfinite(lp));
+  Sampler sampler(rng, handler, target, zero(), ones(), 0.2, 1, 3, 1, 1.0);
+  EXPECT_EQ(target.calls, 1);
+  for (int i = 0; i < 3; ++i) {
+    EXPECT_EQ(sampler(), 0);
+    EXPECT_EQ(handler.samples.back().first.norm(), 0);
+  }
+  EXPECT_EQ(target.calls, 1 + 3 * 7);
+  EXPECT_EQ(handler.errors, 3 * 7);
+
+  target.fail_away_from_origin = false;
+  for (int i = 0; i < 5; ++i) {
+    sampler();
+  }
+  EXPECT_EQ(handler.errors, 3 * 7);
+  EXPECT_GT(handler.samples.back().first.norm(), 0);
 }
 
-TEST(EndpointReuse, WrongSizedCacheFallsBack) {
-  Target t;
+// The returned sampler evaluates its endpoint at the final warmup position,
+// so freezing costs one evaluation.
+TEST(EndpointReuse, FreezeEvaluatesOnceAtFinalWarmupPosition) {
+  Target target;
+  Handler handler;
   std::mt19937_64 rng(17);
-  detail::Random random(rng);
-  detail::NoOpStepSizeAdapter adapter;
-  Eigen::VectorXd wrong_gradient = Eigen::VectorXd::Ones(3);
-  std::size_t depth;
-  Eigen::VectorXd grad;
-  double lp;
-  auto theta = detail::transition_w_impl(random, t, ones(), ones(), 0.1, 1, 1,
-                                         1, 1.0, zero(), depth, grad, lp,
-                                         adapter, &wrong_gradient, 999.0);
-  EXPECT_EQ(t.calls, 2);
-  EXPECT_EQ(grad.size(), theta.size());
-  EXPECT_LE(lp, 0);
+  AdaptiveWalnuts<Target, std::mt19937_64, Handler> adaptive(
+      rng, handler, target, InitChainConfig(0.2, zero(), ones()),
+      WarmupConfigBuilder().build(), SamplingConfigBuilder().build());
+  EXPECT_EQ(target.calls, 1);
+  for (int i = 0; i < 20; ++i) {
+    adaptive();
+  }
+  std::size_t calls = target.calls;
+  auto sampler = adaptive.sampler();
+  EXPECT_EQ(target.calls, calls + 1);
+  EXPECT_EQ(target.last_evaluated, handler.last_warmup);
 }
 
-struct MutatingDensityHandler : Handler {
-  void on_sample(const Eigen::VectorXd& x, double& lp) {
-    Handler::on_sample(x, lp);
-    lp = 12345;
-  }
-  void on_warmup(const Eigen::VectorXd& x, double& lp, double step,
-                 const Eigen::VectorXd& mass) {
-    Handler::on_warmup(x, lp, step, mass);
-    lp = 12345;
-  }
-};
-TEST(EndpointReuse, CallbackDensityReferenceDoesNotChangeStoredEndpoint) {
-  Bits traces[2];
-  std::mt19937_64 states[2];
-  std::size_t counts[2];
-  for (bool reuse : {false, true}) {
-    Target target;
-    MutatingDensityHandler handler;
-    std::mt19937_64 rng(17);
-    auto init = InitChainConfig(.2, zero(), ones());
-    auto warmup = WarmupConfigBuilder().build();
-    auto config = sampling_config();
-    AdaptiveWalnuts adaptive(rng, handler, target, init, warmup, config);
-    for (int i = 0; i < 20; ++i) {
-      draw_with_reuse(adaptive, reuse);
-    }
-    auto sampler = adaptive.sampler();
-    for (int i = 0; i < 20; ++i) {
-      EXPECT_EQ(draw_with_reuse(sampler, reuse), 12345);
-    }
-    traces[reuse] = handler.trace;
-    states[reuse] = rng;
-    counts[reuse] = target.calls;
-  }
-  EXPECT_EQ(traces[0], traces[1]);
-  EXPECT_EQ(states[0], states[1]);
-  EXPECT_EQ(counts[0] - counts[1], 39);
-}
 }  // namespace

--- a/tests/endpoint_test.cpp
+++ b/tests/endpoint_test.cpp
@@ -115,9 +115,11 @@ TEST(EndpointReuse, FreezeEvaluatesOnceAtFinalWarmupPosition) {
   Target target;
   Handler handler;
   std::mt19937_64 rng(17);
+  auto warmup_cfg = WarmupConfigBuilder().build();
+  auto sampling_cfg = SamplingConfigBuilder().build();
   AdaptiveWalnuts<Target, std::mt19937_64, Handler> adaptive(
-      rng, handler, target, InitChainConfig(0.2, zero(), ones()),
-      WarmupConfigBuilder().build(), SamplingConfigBuilder().build());
+      rng, handler, target, InitChainConfig(0.2, zero(), ones()), warmup_cfg,
+      sampling_cfg);
   EXPECT_EQ(target.calls, 1);
   for (int i = 0; i < 20; ++i) {
     adaptive();


### PR DESCRIPTION
Reuse the selected density and gradient instead of evaluating them again at the next transition.

Add opt-in `EndpointReuse::Deterministic` to `WalnutsSampler` and `AdaptiveWalnuts`. The default stays disabled as targets may read a mutable external state.
Caches own finite values, transfer across freeze, and support explicit invalidation. Existing constructor calls and the uncached transition API remain valid.

Three repetitions × four chains × 1,000 warmup + 1,000 draws, with paired seeds and identical model binaries:
| Model | Median enabled/disabled ESS/s | Rep range |
|---|---:|---:|
| dogs_hierarchical | 1.190× | 1.187-1.194× |
| gp_regr | 1.188× | 1.170-1.211× |

ESS/s includes warmup and sampling. Each chain saves 1,999 evaluations (warmup + draws - 1). 

Opt-in requires a stable, position-only target. Invalidate after target changes. Failed endpoints are retried.