### PR TITLE
Reject mass_init_count of one or less at the builder

### DIFF
--- a/include/walnutpie/config.hpp
+++ b/include/walnutpie/config.hpp
@@ -696,10 +696,10 @@ class WarmupConfigBuilder {
    * @param[in] v The mass matrix estimator initial count.
    * @return This builder for chaining.
    * @throw std::invalid_argument If the initial count is not finite and
-   * positive.
+   * greater than one.
    */
   WarmupConfigBuilder& mass_init_count(double v) {
-    detail::validate_finite_positive(v, "mass_init_count");
+    detail::validate_finite_gt1(v, "mass_init_count");
     cfg_.mass_init_count_ = v;
     return *this;
   }

--- a/tests/config_test.cpp
+++ b/tests/config_test.cpp
@@ -617,7 +617,9 @@ TEST(WarmupConfigBuilder, MassInitCountSetsCorrectly) {
 }
 
 TEST(WarmupConfigBuilder, MassInitCountThrowsOnBadValues) {
-  for (auto x : inf_nan_neg_zero()) {
+  std::vector<double> bad = inf_nan_neg_zero();
+  bad.insert(bad.end(), {0.5, 1.0});
+  for (auto x : bad) {
     walnutpie::WarmupConfigBuilder b;
     EXPECT_THROW(b.mass_init_count(x), std::invalid_argument);
   }


### PR DESCRIPTION
The mass estimator's discount factor is `1 - 1/(mass_init_count + iteration)`. The old finite-positive check admitted values that break downstream:

- `1` zeroes the discount on the first observation. Both variance priors are erased (`weight = 1`, `sum_sq_dev = 0`), and `inv_mass_estimate()` computes `sqrt(0/0)` = NaN. Verified on the real `MassEstimator`: unit mass, position 1, gradient -1, count 1 gives NaN; count 4 gives 1.0.
- below `1` the discount is negative and `OnlineMoments::discount_observe` throws `discount_factor must be in [0, 1]`. In `AdaptWorker` that exception escapes the thread function and terminates the process.
