### PR TITLE
Report completed doublings from transition_w

### DIFF
--- a/include/walnutpie/walnuts.hpp
+++ b/include/walnutpie/walnuts.hpp
@@ -512,7 +512,8 @@ static std::optional<SpanW> build_span(Random<RNG>& rng, const F& logp_grad,
  * @param[in] min_micro_steps The minimum number of micro steps per macro step.
  * @param[in] max_error The maximum difference in Hamiltonians.
  * @param[in] theta The current state.
- * @param[out] depth The tree depth used by the transition.
+ * @param[out] depth The number of doublings included in the final
+ * trajectory, which holds `2^depth` states.
  * @param[in,out] theta_grad The gradient of the log density at `theta` on
  * input; the gradient at the selected state on output.
  * @param[in,out] logp_pos_select The log density of `theta` on input; the
@@ -534,12 +535,12 @@ inline Eigen::VectorXd transition_w(
   auto span_accum = SpanW::from_initial_point(std::move(theta), std::move(rho),
                                               std::move(theta_grad),
                                               logp_pos_select, logp_joint);
-  for (depth = 1; depth <= max_depth; ++depth) {
-    // helper to turn runtime direction into compile-time template enum
+  depth = 0;
+  while (depth < max_depth) {
     auto expand_in_direction = [&](auto direction) -> bool {
       constexpr Direction D = direction;
       auto maybe_next_span = build_span<D>(
-          rand, logp_grad, inv_mass, step, depth - 1, max_step_halvings,
+          rand, logp_grad, inv_mass, step, depth, max_step_halvings,
           min_micro_steps, max_error, span_accum, step_size_adapter);
       if (!maybe_next_span) {
         return true;
@@ -547,6 +548,7 @@ inline Eigen::VectorXd transition_w(
       bool combined_uturn = uturn<D>(span_accum, *maybe_next_span, inv_mass);
       span_accum = combine<Update::Metropolis, D>(rand, std::move(span_accum),
                                                   std::move(*maybe_next_span));
+      ++depth;
       return combined_uturn;
     };
 

--- a/tests/walnuts_test.cpp
+++ b/tests/walnuts_test.cpp
@@ -4,6 +4,7 @@
 
 #include <cmath>
 #include <limits>
+#include <random>
 #include <vector>
 
 namespace {
@@ -30,6 +31,23 @@ bool take_macro_step(const F& logp_grad, A& adapter,
   return walnutpie::detail::macro_step<D>(
       logp_grad, Eigen::VectorXd::Ones(1), 1.0, max_halvings, 1, 1.0, span,
       theta, rho, grad, logp_pos, logp, adapter);
+}
+
+template <typename F>
+std::size_t transition_depth(const F& target, std::size_t max_depth,
+                             double step = 0.05) {
+  std::mt19937 rng(7);
+  walnutpie::detail::Random<std::mt19937> rand(rng);
+  walnutpie::detail::NoOpStepSizeAdapter adapter;
+  Eigen::VectorXd theta = Eigen::VectorXd::Zero(2);
+  Eigen::VectorXd grad(2);
+  double logp;
+  target(theta, logp, grad);
+  std::size_t depth;
+  walnutpie::detail::transition_w(
+      rand, target, Eigen::VectorXd::Ones(2), Eigen::VectorXd::Ones(2), step,
+      max_depth, 5, 1, 1.0, std::move(theta), depth, grad, logp, adapter);
+  return depth;
 }
 
 TEST(MacroStepAdaptation, NonfiniteLogDensityIsZeroAcceptanceInBothDirections) {
@@ -96,5 +114,20 @@ TEST(MacroStepAdaptation, ConservedEnergyKeepsUnitAcceptance) {
   RecordingAdapter adapter;
   EXPECT_TRUE(take_macro_step<Direction::Forward>(target, adapter));
   EXPECT_EQ(adapter.observed, std::vector<double>{1.0});
+}
+
+TEST(TransitionDepth, ReportsIncludedDoublings) {
+  auto gaussian = [](const Eigen::VectorXd& x, double& lp, Eigen::VectorXd& g) {
+    lp = -0.5 * x.squaredNorm();
+    g = -x;
+  };
+  for (std::size_t max_depth : {std::size_t{1}, std::size_t{3}}) {
+    EXPECT_EQ(transition_depth(gaussian, max_depth), max_depth);
+  }
+  auto nonfinite = [](const Eigen::VectorXd&, double& lp, Eigen::VectorXd& g) {
+    lp = -std::numeric_limits<double>::infinity();
+    g.setZero();
+  };
+  EXPECT_EQ(transition_depth(nonfinite, 4), 0u);
 }
 }  // namespace


### PR DESCRIPTION
`transition_w`'s `depth` output counts attempted doublings, and the three loop exits disagree with the trajectory it actually built:

- U-turn between spans: the doubling landed; `2^depth` states. Correct.
- Failed expansion (macro step fails or a u-turn inside the new span): the trajectory keeps `2^(depth-1)` states, but `depth` names the attempt.
- Budget exhaustion: `depth == max_depth + 1` while the trajectory holds `2^max_depth` states.

The only in-tree consumer is `min_micro_estimator_.observe(1 << depth)` in `AdaptiveWalnuts::operator()`, documented as receiving the micro steps taken. On every capped or aborted warmup draw it records twice the actual states, biasing `min_micro_steps()` upward: longer macro steps than `max_macro_steps_target` calls for, paid in `logp_grad` calls. 

The fix counts the doublings that land and reports that value