### PR TITLE
Take the absolute step deviation from the geometric mean

### DIFF
--- a/include/walnutpie/adapt.hpp
+++ b/include/walnutpie/adapt.hpp
@@ -212,7 +212,8 @@ inline AdaptResult controller_loop(
         double rel_diff_mass = l2_rel_diff(latest[m].mass, geom_mean_mass);
         max_rel_diff_mass = std::fmax(max_rel_diff_mass, rel_diff_mass);
         double chain_m_step = std::exp(latest[m].log_step);
-        double rel_diff_step = (chain_m_step - geom_mean_step) / geom_mean_step;
+        double rel_diff_step =
+            std::abs(chain_m_step - geom_mean_step) / geom_mean_step;
         max_rel_diff_step = std::fmax(max_rel_diff_step, rel_diff_step);
       }
 

--- a/tests/walnuts_test.cpp
+++ b/tests/walnuts_test.cpp
@@ -1,9 +1,13 @@
 #include <gtest/gtest.h>
 #include <walnutpie/adam.hpp>
+#include <walnutpie/adapt.hpp>
+#include <walnutpie/config.hpp>
 #include <walnutpie/walnuts.hpp>
 
 #include <cmath>
+#include <deque>
 #include <limits>
+#include <stdexcept>
 #include <vector>
 
 namespace {
@@ -96,5 +100,30 @@ TEST(MacroStepAdaptation, ConservedEnergyKeepsUnitAcceptance) {
   RecordingAdapter adapter;
   EXPECT_TRUE(take_macro_step<Direction::Forward>(target, adapter));
   EXPECT_EQ(adapter.observed, std::vector<double>{1.0});
+}
+
+TEST(ControllerLoop, RejectsLowStepWhenHighStepsAreWithinTolerance) {
+  struct StopPolling {
+    void throw_if_interrupted() const {
+      throw std::runtime_error("not converged");
+    }
+  } interrupt;
+  auto init = walnutpie::InitConfigBuilder(3, 1).build();
+  auto warmup_cfg = walnutpie::WarmupConfigBuilder()
+                        .step_size_converge_tol(0.1)
+                        .build();
+  std::deque<walnutpie::detail::SpscBuffer<walnutpie::detail::AdaptSnapshot>>
+      buffers;
+  walnutpie::detail::AdaptSnapshot snap(1);
+  snap.iter = warmup_cfg.min_iter();
+  snap.log_mass.setZero();
+  snap.mass.setOnes();
+  for (double step : {0.8, 1.05, 1.05}) {
+    snap.log_step = std::log(step);
+    buffers.emplace_back(snap);
+  }
+  EXPECT_THROW(
+      walnutpie::detail::controller_loop(buffers, interrupt, init, warmup_cfg),
+      std::runtime_error);
 }
 }  // namespace


### PR DESCRIPTION
`controller_loop`'s step-agreement criterion measures only the signed deviation of each chain's step from the geometric mean. A chain sitting below the mean contributes a negative value, which `fmax` discards.

I didn't find any controller test to fold this one into.